### PR TITLE
Re fetch membership > group field items after saving

### DIFF
--- a/src/Plugin/Field/FieldType/OgMembershipReferenceItemList.php
+++ b/src/Plugin/Field/FieldType/OgMembershipReferenceItemList.php
@@ -39,8 +39,6 @@ class OgMembershipReferenceItemList extends EntityReferenceFieldItemList {
 
   /**
    * {@inheritdoc}
-   *
-   * @todo Need to account for new items added and not being overridden etc..
    */
   public function get($index) {
     if (!is_numeric($index)) {
@@ -103,6 +101,10 @@ class OgMembershipReferenceItemList extends EntityReferenceFieldItemList {
       $entities = $storage->loadMultiple(array_keys($deprecated_membership_ids));
       $storage->delete($entities);
     }
+
+    // Set fetched to FALSE to force a rebuild of the membership group data if
+    // it is used after saving.
+    $this->fetched = FALSE;
   }
 
   /**


### PR DESCRIPTION
I think we can fix the @todo I left on the `OgMembershipItemList::get` method by just making sure we set `$fetched` to `FALSE` at the end of `::postSave`. If the items from the field are requested again after saving, during the same request.

Or are we fine with just leaving the field items that were populated from the widget? This way seems safer. But might be too safe.. Not sure. I guess it's possible that another user/request changed the groups too, so getting the current data again could be a good idea. Memberships are more likely to get lost otherwise?
