### PR TITLE
Fix groups confgig schema to use a dynamic sequence type

### DIFF
--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -3,14 +3,16 @@ og.settings:
   label: 'Organic Groups settings'
   mapping:
     groups:
-      type: mapping
-      mapping:
-        bundles:
-          type: sequence
-          label: 'OG groups'
-          sequence:
-            type: string
-            label: 'Group'
+      type: sequence
+      sequence:
+        type: og.settings.group.[%key]
+
+og.settings.group.*:
+  type: sequence
+  label: 'OG groups'
+  sequence:
+    type: string
+    label: 'Group'
 
 og.og_membership_type.*:
   type: config_entity


### PR DESCRIPTION
This fixes the groups schema by defining the groups as a sequence still, but declaring the type as a dynamic type, which we can then catch with `og.settings.group.*`. This then contains the sequence definition for the bundles.

This should then work correctly with the entity type ID keys we are using.

ping @RoySegall
