### PR TITLE
Fix undefined index notice when requesting groups of an entity that doesn't have any

### DIFF
--- a/src/Og.php
+++ b/src/Og.php
@@ -115,7 +115,7 @@ class Og {
       return static::$entityGroupCache[$identifier];
     }
 
-    $cache[$identifier] = [];
+    static::$entityGroupCache[$identifier] = [];
     $query = \Drupal::entityQuery('og_membership')
       ->condition('entity_type', $entity_type)
       ->condition('etid', $entity_id);


### PR DESCRIPTION
I'm getting the following notice when I try to access a group content node as a user that doesn't have any group memberships:

> Notice: Undefined index: user:1:1: in Drupal\og\Og::getEntityGroups() (line 143 of modules/og/src/Og.php).
