### PR TITLE
Use StringTranslationTrait in OgField plugins

### DIFF
--- a/src/Plugin/OgFields/AccessField.php
+++ b/src/Plugin/OgFields/AccessField.php
@@ -43,8 +43,8 @@ class AccessField extends OgFieldBase implements OgFieldsInterface {
    */
   public function instanceDefinition() {
     return FieldConfig::create(array(
-      'label' => t('Group roles and permissions'),
-      'description' => t('Determine if group should use default roles and permissions.'),
+      'label' => $this->t('Group roles and permissions'),
+      'description' => $this->t('Determine if group should use default roles and permissions.'),
       'default_value' => array(0 => array('value' => 0)),
       'display_label' => 1,
       'required' => TRUE,

--- a/src/Plugin/OgFields/AudienceField.php
+++ b/src/Plugin/OgFields/AudienceField.php
@@ -52,8 +52,8 @@ class AudienceField extends OgFieldBase implements OgFieldsInterface {
    */
   public function instanceDefinition() {
     return FieldConfig::create([
-      'label' => t('Groups audience'),
-      'description' => t('OG group audience reference field.'),
+      'label' => $this->t('Groups audience'),
+      'description' => $this->t('OG group audience reference field.'),
       'display_label' => TRUE,
       'field_name' => OG_AUDIENCE_FIELD,
       'entity_type' => $this->getEntityType(),


### PR DESCRIPTION
Use StringTranslationTrait in OgFieldBase so that translation is avaliable as a public method instead of global.

Creating PR to run through tests.
