### PR TITLE
Convert og_is_member to Og:isMember and add test coverage

### DIFF
--- a/og.module
+++ b/og.module
@@ -1913,30 +1913,6 @@ function _og_get_all_group_content_bundle() {
 }
 
 /**
- * Return TRUE if entity belongs to a group.
- *
- * @param $group_type
- *   The entity type of the group.
- * @param $gid
- *   The group ID.
- * @param $entity_type
- *   The entity type.
- * @param $entity
- *   The entity object. If empty the current user will be used.
- * @param $states
- *   (optional) Array with the state to return. If empty groups of all state will
- *   return.
- *
- * @return
- *   TRUE if the entity (e.g. the user) belongs to a group and is not pending or
- *   blocked.
- */
-function _og_is_member($group_type, $gid, $entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE)) {
-  $groups = og_get_entity_groups($entity_type, $entity, $states);
-  return !empty($groups[$group_type]) && in_array($gid, $groups[$group_type]);
-}
-
-/**
  * Check if group should use default roles and permissions.
  *
  * @param $group_type

--- a/src/Og.php
+++ b/src/Og.php
@@ -178,8 +178,8 @@ class Og {
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity to get groups for.
    * @param array $states
-   *   (optional) Array with the state to return. If empty groups of all state
-   *   will return.
+   *   (optional) Array with the membership states to check the membership.
+   *   Defaults to active memberships.
    *
    * @return bool
    *   TRUE if the entity (e.g. the user) belongs to a group and is not pending
@@ -188,8 +188,8 @@ class Og {
   public static function isMember(EntityInterface $group, EntityInterface $entity, $states = [OG_STATE_ACTIVE]) {
     $groups = static::getEntityGroups($entity, $states);
     $group_entity_type = $group->getEntityTypeId();
-    // We need to create a map of the group ids as getEntityGroups returns a map
-    // of membership_id => group entity for each type.
+    // We need to create a map of the group ids as Og::getEntityGroups returns a
+    // map of membership_id => group entity for each type.
     return !empty($groups[$group_entity_type]) && in_array($group->id(), array_map(function($group_entity) {
       return $group_entity->id();
     }, $groups[$group_entity_type]));

--- a/src/Og.php
+++ b/src/Og.php
@@ -189,6 +189,8 @@ class Og {
    */
   public static function isMember($group_entity_type, $group_id, $entity_type, $entity_id = NULL, $states = [OG_STATE_ACTIVE]) {
     $groups = static::getEntityGroups($entity_type, $entity_id, $states);
+    // We need to create a map of the group ids as getEntityGroups returns a map
+    // of membership_id => group entity for each type.
     return !empty($groups[$group_entity_type]) && in_array($group_id, array_map(function($group) {
       return $group->id();
     }, $groups[$group_entity_type]));

--- a/src/Og.php
+++ b/src/Og.php
@@ -169,6 +169,32 @@ class Og {
   }
 
   /**
+   * Return TRUE if entity belongs to a group.
+   *
+   * @param string $group_entity_type
+   *   The entity type of the group.
+   * @param string|int $group_id
+   *   The group ID.
+   * @param string $entity_type
+   *   The entity type.
+   * @param string|int $entity_id
+   *   The entity ID.
+   * @param array $states
+   *   (optional) Array with the state to return. If empty groups of all state
+   *   will return.
+   *
+   * @return bool
+   *   TRUE if the entity (e.g. the user) belongs to a group and is not pending
+   *   or blocked.
+   */
+  public static function isMember($group_entity_type, $group_id, $entity_type, $entity_id = NULL, $states = [OG_STATE_ACTIVE]) {
+    $groups = static::getEntityGroups($entity_type, $entity_id, $states);
+    return !empty($groups[$group_entity_type]) && in_array($group_id, array_map(function($group) {
+      return $group->id();
+    }, $groups[$group_entity_type]));
+  }
+
+  /**
    * Check if the given entity type and bundle is a group.
    *
    * @param string $entity_type_id

--- a/src/Og.php
+++ b/src/Og.php
@@ -117,7 +117,7 @@ class Og {
    *  then an empty array.
    */
   public static function getEntityGroups(EntityInterface $entity, $states = [OG_STATE_ACTIVE], $field_name = NULL) {
-    $entity_type = $entity->getEntityTypeId();
+    $entity_type_id = $entity->getEntityTypeId();
     $entity_id = $entity->id();
 
     // Get a string identifier of the states, so we can retrieve it from cache.
@@ -130,7 +130,7 @@ class Og {
     }
 
     $identifier = [
-      $entity_type,
+      $entity_type_id,
       $entity_id,
       $state_identifier,
       $field_name,
@@ -144,7 +144,7 @@ class Og {
 
     static::$entityGroupCache[$identifier] = [];
     $query = \Drupal::entityQuery('og_membership')
-      ->condition('entity_type', $entity_type)
+      ->condition('entity_type', $entity_type_id)
       ->condition('etid', $entity_id);
 
     if ($states) {
@@ -187,12 +187,12 @@ class Og {
    */
   public static function isMember(EntityInterface $group, EntityInterface $entity, $states = [OG_STATE_ACTIVE]) {
     $groups = static::getEntityGroups($entity, $states);
-    $group_entity_type = $group->getEntityTypeId();
+    $group_entity_type_id = $group->getEntityTypeId();
     // We need to create a map of the group ids as Og::getEntityGroups returns a
     // map of membership_id => group entity for each type.
-    return !empty($groups[$group_entity_type]) && in_array($group->id(), array_map(function($group_entity) {
+    return !empty($groups[$group_entity_type_id]) && in_array($group->id(), array_map(function($group_entity) {
       return $group_entity->id();
-    }, $groups[$group_entity_type]));
+    }, $groups[$group_entity_type_id]));
   }
 
   /**

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -127,7 +127,7 @@ class OgSelection extends DefaultSelection {
    * @return ContentEntityInterface[]
    */
   protected function getUserGroups() {
-    $other_groups = Og::getEntityGroups('user', $this->currentUser->id());
+    $other_groups = Og::getEntityGroups($this->currentUser->getAccount());
     return isset($other_groups[$this->configuration['target_type']]) ? $other_groups[$this->configuration['target_type']] : [];
   }
 

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -72,7 +72,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
     $parents = $form['#parents'];
 
     $target_type = $this->fieldDefinition->getTargetEntityTypeId();
-    $user_groups = Og::getEntityGroups('user', \Drupal::currentUser()->id());
+    $user_groups = Og::getEntityGroups(\Drupal::currentUser()->getAccount());
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function($group) {
       return $group->id();
@@ -228,7 +228,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
     $target_type = $this->fieldDefinition->getTargetEntityTypeId();
 
-    $user_groups = Og::getEntityGroups('user', \Drupal::currentUser()->id());
+    $user_groups = Og::getEntityGroups(\Drupal::currentUser()->getAccount());
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function($group) {
       return $group->id();

--- a/tests/src/Kernel/Entity/EntityGroupsTest.php
+++ b/tests/src/Kernel/Entity/EntityGroupsTest.php
@@ -52,16 +52,16 @@ class EntityGroupsTest extends KernelTestBase {
   protected $group2;
 
   /**
-   * @var string
-   *
    * The machine name of the group node type.
+   *
+   * @var string
    */
   protected $groupBundle;
 
   /**
-   * @var string
-   *
    * The machine name of the group content node type.
+   *
+   * @var string
    */
   protected $groupContentBundle;
 
@@ -111,12 +111,11 @@ class EntityGroupsTest extends KernelTestBase {
   }
 
   /**
-   * Tests owner groups are returned correctly.
+   * Tests group owners have the correct groups.
    */
   public function testOwnerGroupsOnly() {
     $actual = Og::getEntityGroups('user', $this->user1->id());
 
-    $this->assertArrayHasKey('entity_test', $actual);
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
 
@@ -126,7 +125,6 @@ class EntityGroupsTest extends KernelTestBase {
 
     $actual = Og::getEntityGroups('user', $this->user2->id());
 
-    $this->assertArrayHasKey('entity_test', $actual);
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group2, $actual);
 
@@ -144,14 +142,15 @@ class EntityGroupsTest extends KernelTestBase {
     $this->assertFalse(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
     $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
 
+    // Invalidate the caches so the static cache is cleared and group data is
+    // fetched again for the user.
     Og::invalidateCache();
 
-    // Add to group 1 should return that.
+    // Add user to group 1 should now return that group only.
     $this->createMembership($this->user3, $this->group1);
 
     $actual = Og::getEntityGroups('user', $this->user3->id());
 
-    $this->assertArrayHasKey('entity_test', $actual);
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
 
@@ -165,7 +164,6 @@ class EntityGroupsTest extends KernelTestBase {
 
     $actual = Og::getEntityGroups('user', $this->user3->id());
 
-    $this->assertArrayHasKey('entity_test', $actual);
     $this->assertCount(2, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
     $this->assertGroupExistsInResults($this->group2, $actual);
@@ -175,7 +173,9 @@ class EntityGroupsTest extends KernelTestBase {
   }
 
   /**
-   * Creates an Og membership entity,
+   * Creates an Og membership entity.
+   *
+   * @todo This is a temp function, which will be later replaced by Og::group().
    *
    * @param \Drupal\user\Entity\User $user
    * @param \Drupal\Core\Entity\EntityInterface $group

--- a/tests/src/Kernel/Entity/EntityGroupsTest.php
+++ b/tests/src/Kernel/Entity/EntityGroupsTest.php
@@ -114,23 +114,23 @@ class EntityGroupsTest extends KernelTestBase {
    * Tests group owners have the correct groups.
    */
   public function testOwnerGroupsOnly() {
-    $actual = Og::getEntityGroups('user', $this->user1->id());
+    $actual = Og::getEntityGroups($this->user1);
 
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
 
     // Also check isMember.
-    $this->assertTrue(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user1->id()));
-    $this->assertFalse(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user2->id()));
+    $this->assertTrue(Og::isMember($this->group1, $this->user1));
+    $this->assertFalse(Og::isMember($this->group1, $this->user2));
 
-    $actual = Og::getEntityGroups('user', $this->user2->id());
+    $actual = Og::getEntityGroups($this->user2);
 
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group2, $actual);
 
     // Also check isMember.
-    $this->assertTrue(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user2->id()));
-    $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user1->id()));
+    $this->assertTrue(Og::isMember($this->group2, $this->user2));
+    $this->assertFalse(Og::isMember($this->group2, $this->user1));
   }
 
   /**
@@ -138,9 +138,9 @@ class EntityGroupsTest extends KernelTestBase {
    */
   public function testOtherGroups() {
     // Should be a part of no groups.
-    $this->assertEquals([], Og::getEntityGroups('user', $this->user3->id()));
-    $this->assertFalse(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
-    $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
+    $this->assertEquals([], Og::getEntityGroups($this->user3));
+    $this->assertFalse(Og::isMember($this->group1, $this->user3));
+    $this->assertFalse(Og::isMember($this->group2, $this->user3));
 
     // Invalidate the caches so the static cache is cleared and group data is
     // fetched again for the user.
@@ -149,27 +149,27 @@ class EntityGroupsTest extends KernelTestBase {
     // Add user to group 1 should now return that group only.
     $this->createMembership($this->user3, $this->group1);
 
-    $actual = Og::getEntityGroups('user', $this->user3->id());
+    $actual = Og::getEntityGroups($this->user3);
 
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
 
-    $this->assertTrue(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
-    $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
+    $this->assertTrue(Og::isMember($this->group1, $this->user3));
+    $this->assertFalse(Og::isMember($this->group2, $this->user3));
 
     Og::invalidateCache();
 
     // Add to group 2 should also return that.
     $this->createMembership($this->user3, $this->group2);
 
-    $actual = Og::getEntityGroups('user', $this->user3->id());
+    $actual = Og::getEntityGroups($this->user3);
 
     $this->assertCount(2, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
     $this->assertGroupExistsInResults($this->group2, $actual);
 
-    $this->assertTrue(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
-    $this->assertTrue(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
+    $this->assertTrue(Og::isMember($this->group1, $this->user3));
+    $this->assertTrue(Og::isMember($this->group2, $this->user3));
   }
 
   /**

--- a/tests/src/Kernel/Entity/EntityGroupsTest.php
+++ b/tests/src/Kernel/Entity/EntityGroupsTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\og\Kernel\Entity\EntityGroupsTest.
+ */
+
+namespace Drupal\Tests\og\Kernel\Entity;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Component\Utility\Unicode;
+use Drupal\og\Entity\OgMembership;
+use Drupal\og\Og;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests entity group methods
+ *
+ * @group og
+ */
+class EntityGroupsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['system', 'user', 'field', 'og', 'entity_test'];
+
+  /**
+   * @var \Drupal\user\Entity\User
+   */
+  protected $user1;
+
+  /**
+   * @var \Drupal\user\Entity\User
+   */
+  protected $user2;
+
+  /**
+   * @var \Drupal\user\Entity\User
+   */
+  protected $user3;
+
+  /**
+   * @var \Drupal\entity_test\Entity\EntityTest
+   */
+  protected $group1;
+
+  /**
+   * @var \Drupal\entity_test\Entity\EntityTest
+   */
+  protected $group2;
+
+  /**
+   * @var string
+   *
+   * The machine name of the group node type.
+   */
+  protected $groupBundle;
+
+  /**
+   * @var string
+   *
+   * The machine name of the group content node type.
+   */
+  protected $groupContentBundle;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig(['og']);
+    $this->installEntitySchema('og_membership');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('entity_test');
+    $this->installSchema('system', 'sequences');
+
+    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupContentBundle = Unicode::strtolower($this->randomMachineName());
+
+    // Create users.
+    $this->user1 = User::create(['name' => $this->randomString()]);
+    $this->user1->save();
+
+    $this->user2 = User::create(['name' => $this->randomString()]);
+    $this->user2->save();
+
+    $this->user3 = User::create(['name' => $this->randomString()]);
+    $this->user3->save();
+
+    // Define the group content as group.
+    Og::groupManager()->addGroup('entity_test', $this->groupBundle);
+
+    // Create a group and associate with user 1.
+    $this->group1 = EntityTest::create([
+      'type' => $this->groupBundle,
+      'name' => $this->randomString(),
+      'user_id' => $this->user1->id(),
+    ]);
+    $this->group1->save();
+
+    // Create a group and associate with user 2.
+    $this->group2 = EntityTest::create([
+      'type' => $this->groupBundle,
+      'name' => $this->randomString(),
+      'user_id' => $this->user2->id(),
+    ]);
+    $this->group2->save();
+  }
+
+  /**
+   * Tests owner groups are returned correctly.
+   */
+  public function testOwnerGroupsOnly() {
+    $actual = Og::getEntityGroups('user', $this->user1->id());
+
+    $this->assertArrayHasKey('entity_test', $actual);
+    $this->assertCount(1, $actual['entity_test']);
+    $this->assertGroupExistsInResults($this->group1, $actual);
+
+    // Also check isMember.
+    $this->assertTrue(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user1->id()));
+    $this->assertFalse(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user2->id()));
+
+    $actual = Og::getEntityGroups('user', $this->user2->id());
+
+    $this->assertArrayHasKey('entity_test', $actual);
+    $this->assertCount(1, $actual['entity_test']);
+    $this->assertGroupExistsInResults($this->group2, $actual);
+
+    // Also check isMember.
+    $this->assertTrue(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user2->id()));
+    $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user1->id()));
+  }
+
+  /**
+   * Tests other groups users are added to.
+   */
+  public function testOtherGroups() {
+    // Should be a part of no groups.
+    $this->assertEquals([], Og::getEntityGroups('user', $this->user3->id()));
+    $this->assertFalse(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
+    $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
+
+    Og::invalidateCache();
+
+    // Add to group 1 should return that.
+    $this->createMembership($this->user3, $this->group1);
+
+    $actual = Og::getEntityGroups('user', $this->user3->id());
+
+    $this->assertArrayHasKey('entity_test', $actual);
+    $this->assertCount(1, $actual['entity_test']);
+    $this->assertGroupExistsInResults($this->group1, $actual);
+
+    $this->assertTrue(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
+    $this->assertFalse(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
+
+    Og::invalidateCache();
+
+    // Add to group 2 should also return that.
+    $this->createMembership($this->user3, $this->group2);
+
+    $actual = Og::getEntityGroups('user', $this->user3->id());
+
+    $this->assertArrayHasKey('entity_test', $actual);
+    $this->assertCount(2, $actual['entity_test']);
+    $this->assertGroupExistsInResults($this->group1, $actual);
+    $this->assertGroupExistsInResults($this->group2, $actual);
+
+    $this->assertTrue(Og::isMember('entity_test', $this->group1->id(), 'user', $this->user3->id()));
+    $this->assertTrue(Og::isMember('entity_test', $this->group2->id(), 'user', $this->user3->id()));
+  }
+
+  /**
+   * Creates an Og membership entity,
+   *
+   * @param \Drupal\user\Entity\User $user
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *
+   * @return \Drupal\og\Entity|OgMembership
+   */
+  protected function createMembership($user, $group) {
+    $membership = OgMembership::create(['type' => OG_MEMBERSHIP_TYPE_DEFAULT])
+      ->setEntityId($user->id())
+      ->setEntityType('user')
+      ->setGid($group->id())
+      ->setGroupType($group->getEntityTypeId())
+      ->save();
+
+    return $membership;
+  }
+
+  /**
+   * Asserts whether a group ID exists in some results.
+   *
+   * Assumes entity_type is used.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group_to_check
+   * @param array $results
+   */
+  protected function assertGroupExistsInResults($group_to_check, array $results) {
+    $found = FALSE;
+    foreach ($results['entity_test'] as $group) {
+      if ($group->id() == $group_to_check->id()) {
+        $found = TRUE;
+        break;
+      }
+    }
+
+    $this->assertTrue($found);
+  }
+
+}

--- a/tests/src/Kernel/Entity/GetEntityGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetEntityGroupsTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\Tests\og\Kernel\Entity\EntityGroupsTest.
+ * Contains \Drupal\Tests\og\Kernel\Entity\GetEntityGroupsTest.
  */
 
 namespace Drupal\Tests\og\Kernel\Entity;
@@ -15,11 +15,11 @@ use Drupal\og\Og;
 use Drupal\user\Entity\User;
 
 /**
- * Tests entity group methods
+ * Tests getting the memberships of an entity.
  *
  * @group og
  */
-class EntityGroupsTest extends KernelTestBase {
+class GetEntityGroupsTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
This converts the method and adds new test coverage for it. The `EntityGroupsTest` also covers `Og::getEntityGroups` as `Og::isMember` is basically that and doesn't currently have coverage.
