### PR TITLE
Fatal error in `OgComplex::formMultipleElements()`

### DIFF
--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -9,12 +9,13 @@ namespace Drupal\og\Plugin\Field\FieldWidget;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldFilteredMarkup;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Field\Plugin\Field\FieldWidget\EntityReferenceAutocompleteWidget;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\og\Og;
-use Drupal\Core\Field\FieldFilteredMarkup;
+use Drupal\user\Entity\User;
 
 /**
  * Plugin implementation of the 'entity_reference autocomplete' widget.
@@ -72,7 +73,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
     $parents = $form['#parents'];
 
     $target_type = $this->fieldDefinition->getTargetEntityTypeId();
-    $user_groups = Og::getEntityGroups(\Drupal::currentUser()->getAccount());
+    $user_groups = Og::getEntityGroups(User::load(\Drupal::currentUser()->id()));
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function($group) {
       return $group->id();
@@ -228,7 +229,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
     $target_type = $this->fieldDefinition->getTargetEntityTypeId();
 
-    $user_groups = Og::getEntityGroups(\Drupal::currentUser()->getAccount());
+    $user_groups = Og::getEntityGroups(User::load(\Drupal::currentUser()->id()));
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function($group) {
       return $group->id();


### PR DESCRIPTION
Since #53 went in a fatal error now occurs when visiting the field UI configuration page of a group audience field:

```
Recoverable fatal error: Argument 1 passed to Drupal\og\Og::getEntityGroups() must implement interface Drupal\Core\Entity\EntityInterface, instance of Drupal\Core\Session\UserSession given, called in /home/pieter/v/drupal/drupal/modules/og/src/Plugin/Field/FieldWidget/OgComplex.php on line 75 and defined in Drupal\og\Og::getEntityGroups() (line 119 of modules/og/src/Og.php).
```

This is because a type hint was added on `Og::getEntityGroups()` to check that the passed in entity conforms to `EntityInterface`. This is a good chance, but we were unknowingly passing a `UserSession` object which is a lighter representation of the currently logged in user. We need to pass the full user entity instead.
