### PR TITLE
Selected target bundles are not saved

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\og\Og;
+use Drupal\og\OgGroupAudienceHelper;
 use Drupal\og_ui\BundleFormAlter;
 
 /**
@@ -65,16 +66,16 @@ function og_ui_entity_type_save(EntityInterface $entity) {
   $is_group_content = Og::isGroupContent($entity_type_id, $bundle);
   if ($entity->og_group_content_bundle != $is_group_content) {
     if ($entity->og_group_content_bundle) {
-      Og::createField(OG_AUDIENCE_FIELD, $entity_type_id, $bundle);
+      Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, $entity_type_id, $bundle);
     }
-    elseif ($field = FieldConfig::loadByName($entity_type_id, $bundle, OG_AUDIENCE_FIELD)) {
+    elseif ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelper::DEFAULT_FIELD)) {
       $field->delete();
       return;
     }
   }
 
   // Change the field target type and bundle.
-  if ($field = FieldConfig::loadByName($entity_type_id, $bundle, OG_AUDIENCE_FIELD)) {
+  if ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelper::DEFAULT_FIELD)) {
     $handler_settings = $field->getSetting('handler_settings');
     $save = FALSE;
     foreach (['target_type', 'target_bundles'] as $key) {

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\og\Og;
+use Drupal\og\OgGroupAudienceHelper;
 
 /**
  * Helper for og_ui_form_alter().
@@ -112,7 +113,7 @@ class BundleFormAlter {
 
     $target_type_default = FALSE;
     $handler_settings = [];
-    if ($field = FieldConfig::loadByName($this->entityTypeId, $this->bundle, OG_AUDIENCE_FIELD)) {
+    if ($field = FieldConfig::loadByName($this->entityTypeId, $this->bundle, OgGroupAudienceHelper::DEFAULT_FIELD)) {
       $handler_settings = $field->getSetting('handler_settings');
       if (isset($handler_settings['target_type'])) {
         $target_type_default = $handler_settings['target_type'];

--- a/og_ui/src/Tests/BundleFormAlterTest.php
+++ b/og_ui/src/Tests/BundleFormAlterTest.php
@@ -10,7 +10,7 @@ namespace Drupal\og_ui\Tests;
 use Drupal\simpletest\WebTestBase;
 
 /**
- * Create a new og group and content
+ * Test making a bundle a group and a group content.
  *
  * @group og
  */

--- a/og_ui/src/Tests/BundleFormAlterTest.php
+++ b/og_ui/src/Tests/BundleFormAlterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\og_ui\Tests\BundleFormAlterTest.
+ */
+
+namespace Drupal\og_ui\Tests;
+
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Create a new og group and content
+ *
+ * @group og
+ */
+class BundleFormAlterTest extends WebTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['node', 'og_ui'];
+
+  public function testCreate() {
+    $web_user = $this->drupalCreateUser(array('bypass node access', 'administer content types'));
+    $this->drupalLogin($web_user);
+    $edit = [
+      'name' => 'school',
+      'type' => 'school',
+      'og_is_group' => 1,
+    ];
+    $this->drupalPostForm('admin/structure/types/add', $edit, t('Save content type'));
+    $edit = [
+      'name' => 'class',
+      'type' => 'class',
+      'og_group_content_bundle' => 1,
+      'og_target_type' => 'node',
+      'og_target_bundles[]' => ['school'],
+    ];
+    $this->drupalPostForm('admin/structure/types/add', $edit, t('Save content type'));
+    $this->drupalGet('admin/structure/types/manage/class');
+    $this->assertOptionSelected('edit-og-target-bundles', 'school');
+  }
+
+}


### PR DESCRIPTION
#73

The test itself passes but then
```
Fail      Fatal erro Unknown              0 Unknown                            
    [07-Dec-2015 17:45:05 Australia/Sydney] Uncaught PHP Exception
    Drupal\Core\Config\Schema\SchemaIncompleteException: "Schema errors for
    field.field.node.class.og_group_ref with the following errors:
    field.field.node.class.og_group_ref:settings.handler_settings.target_type
    missing schema" at
    /home/chx/www/d8/core/lib/Drupal/Core/Config/Testing/ConfigSchemaChecker.php
    line 98
```

and reading the schema YML has

```
field.storage_settings.og_membership_reference:
  type: mapping
  label: 'Organic Groups reference field storage settings'
  mapping:
    target_type:
      type: string
      label: 'Type of entity to reference'
```

but this makes no sense, the target_type needs to be per bundle... or so I thought? Why is it on field_storage instead of field_config? If I change mechanically to FieldStorageConfig https://paste.kde.org/pd1hsnjof then the test fails.  @damiankloip please explain. This is a followup, obviously.