### PR TITLE
Check for selection handler from field configuration

### DIFF
--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -37,7 +37,11 @@ class OgSelection extends DefaultSelection {
    * @return DefaultSelection
    */
   public function getSelectionHandler() {
-    return \Drupal::service('plugin.manager.entity_reference_selection')->getSelectionHandler($this->getConfiguration('field'));
+    $field = $this->getConfiguration('field');
+
+    if ($field) {
+      return \Drupal::service('plugin.manager.entity_reference_selection')->getSelectionHandler($field);
+    }
   }
 
   /**
@@ -60,7 +64,14 @@ class OgSelection extends DefaultSelection {
     // the default selection handler of the entity, which the field reference
     // to, and add another logic to the query object i.e. check if the entities
     // bundle defined as group.
-    $query = $this->getSelectionHandler()->buildEntityQuery();
+    $selection_handler = $this->getSelectionHandler();
+
+    if (empty($selection_handler)) {
+      return $query = parent::buildEntityQuery($match, $match_operator);
+    }
+    else {
+      $query = $selection_handler->buildEntityQuery($match, $match_operator);
+    }
 
     $target_type = $this->configuration['target_type'];
 

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -25,7 +25,7 @@ use Drupal\og\Og;
  * @EntityReferenceSelection(
  *   id = "og:default",
  *   label = @Translation("OG selection"),
- *   group = "default",
+ *   group = "og",
  *   weight = 1
  * )
  */


### PR DESCRIPTION
…a query in OgSelection

Me and @pfresson saw this last week. It's pretty blocking, as it happens when creating any new nodes OR users. And that is just what I have tried it on. I think it will affect anything really.

I think part of the problem is that our selection handler is generic, so it doesn't apply to any particular type and it's in the default group, so maybe it gets chosen because of that, I think we might want to change the group too. This manifests itself when validators run, and selection handlers for the fields try to get referenceable entities to validate the entity before save.

This currently checks for a field first, as things break hard when that is not available. So at least we have something more robust.

I am changing the group too. That is actually the only fix that is needed to stop the fatals. Seems quite fragile though - if we were just to rely on the selection handler selection alone.
