### PR TITLE
Fix selection handler for OgComplex case

### DIFF
--- a/src/Og.php
+++ b/src/Og.php
@@ -414,9 +414,9 @@ class Og {
   /**
    * Get the selection handler for an audience field attached to entity.
    *
-   * @param $entity
+   * @param string $entity_type_id
    *   The entity type.
-   * @param $bundle
+   * @param string $bundle_id
    *   The bundle name.
    * @param $field_name
    *   The field name.
@@ -426,8 +426,8 @@ class Og {
    * @return OgSelection
    * @throws \Exception
    */
-  public static function getSelectionHandler($entity, $bundle, $field_name, array $options = []) {
-    $field_definition = FieldConfig::loadByName($entity, $bundle, $field_name);
+  public static function getSelectionHandler($entity_type_id, $bundle_id, $field_name, array $options = []) {
+    $field_definition = FieldConfig::loadByName($entity_type_id, $bundle_id, $field_name);
 
     if (!static::isGroupAudienceField($field_definition)) {
       throw new \Exception(new FormattableMarkup('The field @name is not an audience field.', ['@name' => $field_name]));

--- a/src/Og.php
+++ b/src/Og.php
@@ -435,7 +435,6 @@ class Og {
 
     $options = NestedArray::mergeDeep([
       'target_type' => $field_definition->getFieldStorageDefinition()->getSetting('target_type'),
-      'field' => $field_definition,
       'handler' => $field_definition->getSetting('handler'),
       'handler_settings' => [
         'field_mode' => 'default',

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -39,12 +39,11 @@ class OgSelection extends DefaultSelection {
   public function getSelectionHandler() {
     $options = [
       'target_type' => $this->configuration['target_type'],
-      // This is intentionally NULL as we want the selection manager to choose
-      // the best option.
-      'handler' => NULL,
+      // 'handler' key intentionally absent as we want the selection manager to
+      // choose the best option.
+      // @see \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManager::getInstance()
       'handler_settings' => $this->configuration['handler_settings'],
     ];
-
     return \Drupal::service('plugin.manager.entity_reference_selection')->getInstance($options);
   }
 
@@ -69,6 +68,7 @@ class OgSelection extends DefaultSelection {
     // to, and add another logic to the query object i.e. check if the entities
     // bundle defined as group.
     $selection_handler = $this->getSelectionHandler();
+    $query = $selection_handler->buildEntityQuery($match, $match_operator);
 
     $target_type = $this->configuration['target_type'];
 

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -38,7 +38,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $parent = parent::formElement($items, $delta, $element, $form, $form_state);
     // todo: fix the definition in th UI level.
-    $parent['target_id']['#selection_handler'] = 'default:og';
+    $parent['target_id']['#selection_handler'] = 'og:default';
     $parent['target_id']['#selection_settings']['field_mode'] = 'default';
 
     return $parent;
@@ -286,8 +286,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
         // @todo Allow this to be configurable with a widget setting.
         '#type' => 'entity_autocomplete',
         '#target_type' => $this->fieldDefinition->getTargetEntityTypeId(),
-        // todo: fix the definition in th UI level.
-        '#selection_handler' => 'default:og',
+        '#selection_handler' => 'og:default',
         '#selection_settings' => [
           'other_groups' => TRUE,
           'field_mode' => 'admin',

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -117,8 +117,6 @@ class SelectionHandlerTest extends KernelTestBase {
    */
   public function testSelectionHandler() {
     $this->assertEquals(get_class($this->selectionHandler->getSelectionHandler()), 'Drupal\node\Plugin\EntityReferenceSelection\NodeSelection');
-    $this->assertEquals($this->selectionHandler->getConfiguration('handler'), 'default:node');
-    $this->assertEquals($this->selectionHandler->getConfiguration('target_type'), 'node');
   }
 
   /**


### PR DESCRIPTION
The `OgSelection` handler relies on a field key being set in configuration, this is only possible if `Og::GetSelectionHandler` is used. But this is not possible when using an entity reference element on a form, this will be using the EntityAutocomplete element, so we need to be able to load based on that.

Really we don't need the field at all. We just use the `getInstance` method instead of the getSelectionHandler() method on the selection manager.

Earlier there was https://github.com/amitaibu/og/pull/81 but that only stops the immediate fatal, there were far more issues when using the handler with our widget etc...
