### PR TITLE
Don't add empty item to list in OgMembershipReferenceItemList::get

### DIFF
--- a/src/Plugin/Field/FieldType/OgMembershipReferenceItemList.php
+++ b/src/Plugin/Field/FieldType/OgMembershipReferenceItemList.php
@@ -51,9 +51,10 @@ class OgMembershipReferenceItemList extends EntityReferenceFieldItemList {
       $this->fetched = TRUE;
     }
 
-    // Automatically create the first item for computed fields.
+    // Just return an empty item if the first item is requested and the list is
+    // empty.
     if ($index == 0 && !isset($this->list[0])) {
-      $this->list[0] = $this->createItem(0);
+      return $this->createItem(0);
     }
 
     return isset($this->list[$index]) ? $this->list[$index] : NULL;

--- a/src/Plugin/Field/FieldType/OgMembershipReferenceItemList.php
+++ b/src/Plugin/Field/FieldType/OgMembershipReferenceItemList.php
@@ -52,7 +52,7 @@ class OgMembershipReferenceItemList extends EntityReferenceFieldItemList {
     }
 
     // Just return an empty item if the first item is requested and the list is
-    // empty.
+    // empty. Storing this in the list would lead to an incorrect count.
     if ($index == 0 && !isset($this->list[0])) {
       return $this->createItem(0);
     }


### PR DESCRIPTION
I will create a core issue for this too as the `ItemList` class suffers the same problem.

Doing the following:

``` php
$group_content->og_group_ref->count() // 0 - correct
$group_content->og_group_ref->value // NULL - correct
$group_content->og_group_ref->count() // 1 - Incorrect, should still be 0, we have no items!
```
