### PR TITLE
Add isMemberPending and isMemberBlocked helper methods

### DIFF
--- a/src/Og.php
+++ b/src/Og.php
@@ -194,6 +194,34 @@ class Og {
   }
 
   /**
+   * Returns whether an entity belongs to a group with a pending status.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *
+   * @return bool
+   *
+   * @see \Drupal\og\Og::isMember
+   */
+  public static function isMemberPending(EntityInterface $group, EntityInterface $entity) {
+    return static::isMember($group, $entity, [OgMembershipInterface::STATE_PENDING]);
+  }
+
+  /**
+   * Returns whether an entity belongs to a group with a blocked status.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *
+   * @return bool
+   *
+   * @see \Drupal\og\Og::isMember
+   */
+  public static function isMemberBlocked(EntityInterface $group, EntityInterface $entity) {
+    return static::isMember($group, $entity, [OgMembershipInterface::STATE_BLOCKED]);
+  }
+
+  /**
    * Check if the given entity type and bundle is a group.
    *
    * @param string $entity_type_id


### PR DESCRIPTION
Makes sense to have some additional helpers/shortcuts to check if members are pending or blocked. So instead of always having to do this:

``` php
Og::isMember($group, $user, [OgMembershipInterface::STATE_PENDING])
```

It would be cool to just do:

``` php
Og::isMemberPending($group, $user)
```

Then if you need multiple, just continue to use `isMember`.
