### PR TITLE
Fix recoverable fatal error in og_entity_create_access

### DIFF
--- a/og.module
+++ b/og.module
@@ -165,7 +165,7 @@ function og_entity_create_access(AccountInterface $account, array $context, $bun
       continue;
     }
 
-    $handler = Og::getSelectionHandler($entity_type_id, $bundle, $field_definition);
+    $handler = Og::getSelectionHandler($field_definition);
 
     if ($handler->getReferenceableEntities()) {
       return Accessresult::allowed();

--- a/src/Og.php
+++ b/src/Og.php
@@ -445,22 +445,17 @@ class Og {
   /**
    * Get the selection handler for an audience field attached to entity.
    *
-   * @param string $entity_type_id
-   *   The entity type.
-   * @param string $bundle_id
-   *   The bundle name.
-   * @param $field_name
-   *   The field name.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The field definition.
    * @param array $options
    *   Overriding the default options of the selection handler.
    *
    * @return OgSelection
    * @throws \Exception
    */
-  public static function getSelectionHandler($entity_type_id, $bundle_id, $field_name, array $options = []) {
-    $field_definition = FieldConfig::loadByName($entity_type_id, $bundle_id, $field_name);
-
+  public static function getSelectionHandler(FieldDefinitionInterface $field_definition, array $options = []) {
     if (!static::isGroupAudienceField($field_definition)) {
+      $field_name = $field_definition->getName();
       throw new \Exception("The field $field_name is not an audience field.");
     }
 

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -61,6 +61,13 @@ class SelectionHandlerTest extends KernelTestBase {
   protected $groupContentBundle;
 
   /**
+   * The field definition used in this test.
+   *
+   * @var \Drupal\Core\Field\FieldDefinitionInterface
+   */
+  protected $fieldDefinition;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {
@@ -93,10 +100,10 @@ class SelectionHandlerTest extends KernelTestBase {
     Og::groupManager()->addGroup('node', $this->groupBundle);
 
     // Add og audience field to group content.
-    Og::CreateField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $this->groupContentBundle);
+    $this->fieldDefinition = Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $this->groupContentBundle);
 
     // Get the storage of the field.
-    $this->selectionHandler = Og::getSelectionHandler('node', $this->groupContentBundle, OgGroupAudienceHelper::DEFAULT_FIELD, ['handler_settings' => ['field_mode' => 'default']]);
+    $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['handler_settings' => ['field_mode' => 'default']]);
 
     // Create two users.
     $this->user1 = User::create(['name' => $this->randomString()]);
@@ -140,7 +147,7 @@ class SelectionHandlerTest extends KernelTestBase {
 
     // Check the other groups.
 
-    $this->selectionHandler = Og::getSelectionHandler('node', $this->groupContentBundle, OgGroupAudienceHelper::DEFAULT_FIELD, ['handler_settings' => ['field_mode' => 'admin']]);
+    $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['handler_settings' => ['field_mode' => 'admin']]);
 
     $this->setCurrentAccount($this->user1);
     $groups = $this->selectionHandler->getReferenceableEntities();


### PR DESCRIPTION
Mentioned in passing last week to a couple of people, just saw this on the installation now that more entity access code is running. `og_entity_create_access` makes a call to `Og::getSelectionHandler` but tries to pass the whole field definition instead of just the field name, which is what the method is expecting.

However, the only reason we need $entity_type, $bundle, AND $field_name is to load the field definition, but in all cases, we already have the field definition, so we might as well just pass that to get the handler. We will always be able to get the field definition easily if we have that info anyway. The getSelectionHandler only really needs the field definition, so let's wind in the scope of that method to not deal with loading definitions too.
