### PR TITLE
Add a composer manifest.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "drupal/og",
+    "description": "API to allow associating content with groups.",
+    "type": "drupal-module",
+    "license": "GPL-2.0+",
+    "homepage": "https://drupal.org/project/og",
+    "support": {
+        "issues": "https://drupal.org/project/issues/og",
+        "irc": "irc://irc.freenode.org/drupal-og",
+        "source": "https://cgit.drupalcode.org/og"
+    },
+    "minimum-stability": "dev"
+}


### PR DESCRIPTION
In order to be able to install OG through composer we need to add a `composer.json` file. I created one according to the instructions at [Add a composer.json file](https://www.drupal.org/node/2514612).
