### PR TITLE
Cannot reference bundleless group entities

### DIFF
--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -72,12 +72,17 @@ class OgSelection extends DefaultSelection {
 
     $target_type = $this->configuration['target_type'];
 
-    $identifier_key = \Drupal::entityTypeManager()->getDefinition($target_type)->getKey('id');
+    $entity_type = \Drupal::entityTypeManager()->getDefinition($target_type);
+    $identifier_key = $entity_type->getKey('id');
+    $bundle_key = $entity_type->getKey('bundle');
+
+    // Filter per bundle for entities that have bundles.
+    if ($bundle_key) {
+      $bundles = Og::groupManager()->getAllGroupBundles($target_type);
+      $query->condition($bundle_key, $bundles, 'IN');
+    }
+
     $user_groups = $this->getUserGroups();
-    $bundles = Og::groupManager()->getAllGroupBundles($target_type);
-
-    $query->condition('type', $bundles, 'IN');
-
     if (!$user_groups) {
       return $query;
     }


### PR DESCRIPTION
I have a custom "Group" entity type that doesn't have bundles since I only have one group type on my project. When I try to add a reference to a Group entity in the group audience field I get the following exception in the ajax callback:

> Drupal\Core\Entity\Query\QueryException: 'type' not found in core/lib/Drupal/Core/Entity/Query/Sql/Tables.php on line 252

This happens because `OgSelection::buildEntityQuery()` assumes that all entities have bundles. It also assumes that the entity key for bundles is always "type" - this just happens to be the bundle key that is used for nodes, but for example for taxonomy terms this is "vid".
