### PR TITLE
Fatal error when unselecting target bundles in group content settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - nohup php -S localhost:8888 > /dev/null 2>&1 &
 
   # Wait until the web server is responding.
-  - until curl -s 127.0.0.1:8888; do true; done > /dev/null
+  - until curl -s localhost:8888; do true; done > /dev/null
 
   # Export web server URL for browser tests.
   - export SIMPLETEST_BASE_URL=http://localhost:8888

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,39 @@ mysql:
   encoding: utf8
 
 before_script:
-  # Remember the current rules test directory for later use in the Drupal
-  # installation.
+  # Remove Xdebug as we don't need it and it causes "PHP Fatal error: Maximum
+  # function nesting level of '256' reached."
+  # We also don't care if that file exists or not on PHP 7.
+  - phpenv config-rm xdebug.ini || true
+
+  # Remember the current directory for later use in the Drupal installation.
   - TESTDIR=$(pwd)
+
   # Navigate out of module directory to prevent blown stack by recursive module
   # lookup.
   - cd ..
 
   # Create database.
   - mysql -e 'create database og'
+
+  # Export database variable for kernel tests.
+  - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
+
   # Download Drupal 8 core.
-  - git clone --branch $DRUPAL_CORE --depth 1 http://git.drupal.org/project/drupal.git
+  - travis_retry git clone --branch $DRUPAL_CORE --depth 1 https://git.drupal.org/project/drupal.git
   - cd drupal
 
+  # Reference OG in the Drupal site.
   - ln -s $TESTDIR modules/og
 
-  # Adding DB so PHPUnit could mock the environment.
-  - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og;
+  # Start a web server on port 8888 in the background.
+  - nohup php -S localhost:8888 > /dev/null 2>&1 &
+
+  # Wait until the web server is responding.
+  - until curl -s 127.0.0.1:8888; do true; done > /dev/null
+
+  # Export web server URL for browser tests.
+  - export SIMPLETEST_BASE_URL=http://localhost:8888
 
 script:
   # Run the PHPUnit tests which also include the kernel tests.

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -165,7 +165,7 @@ class BundleFormAlter {
         '#title' => t('Target type'),
         '#options' => $target_types,
         '#default_value' => $target_type_default,
-        '#description' => t('The entity type that can be referenced thru this field.'),
+        '#description' => t('The entity type that can be referenced through this field.'),
         '#ajax' => array(
           'callback' => [$this, 'ajaxCallback'],
           'wrapper' => 'og-settings-wrapper',
@@ -184,7 +184,7 @@ class BundleFormAlter {
         '#type' => 'select',
         '#title' => t('Target bundles'),
         '#options' => $bundle_options,
-        '#default_value' => isset($handler_settings['target_bundles']) ? $handler_settings['target_bundles'] : [],
+        '#default_value' => !empty($handler_settings['target_bundles']) ? $handler_settings['target_bundles'] : NULL,
         '#multiple' => TRUE,
         '#description' => t('The bundles of the entity type that can be referenced. Optional, leave empty for all bundles.'),
         '#states' => array(
@@ -193,10 +193,25 @@ class BundleFormAlter {
           ),
         ),
       );
+      $form['#validate'][] = [get_class($this), 'validateTargetBundleElement'];
     }
     else {
       $form['og']['og_group_content_bundle']['#disabled'] = TRUE;
     }
   }
+
+  /**
+   * Element validate handler for the og_target_bundles element.
+   */
+  public static function validateTargetBundleElement(array &$form, FormStateInterface $form_state) {
+    // If no checkboxes were checked for 'og_target_bundles', store NULL ("all
+    // bundles are referenceable") rather than empty array ("no bundle is
+    // referenceable" - typically happens when all referenceable bundles have
+    // been deleted).
+    if ($form_state->getValue('og_target_bundles') === []) {
+      $form_state->setValue('og_target_bundles', NULL);
+    }
+  }
+
 
 }

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -201,7 +201,7 @@ class BundleFormAlter {
   }
 
   /**
-   * Element validate handler for the og_target_bundles element.
+   * Form validate handler.
    */
   public static function validateTargetBundleElement(array &$form, FormStateInterface $form_state) {
     // If no checkboxes were checked for 'og_target_bundles', store NULL ("all

--- a/og_ui/src/Tests/BundleFormAlterTest.php
+++ b/og_ui/src/Tests/BundleFormAlterTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\og_ui\Tests;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\simpletest\WebTestBase;
 
 /**
@@ -42,6 +43,38 @@ class BundleFormAlterTest extends WebTestBase {
     $this->drupalPostForm('admin/structure/types/add', $edit, t('Save content type'));
     $this->drupalGet('admin/structure/types/manage/class');
     $this->assertOptionSelected('edit-og-target-bundles', 'school');
+    $this->assertTargetBundles(['school' => 'school'], 'The target bundles are set to the "school" bundle.');
+
+    // Test that if the target bundles are unselected, the value for the target
+    // bundles becomes NULL rather than an empty array. The entity reference
+    // selection plugin considers the value NULL to mean 'all bundles', while an
+    // empty array means 'no bundles are allowed'.
+    // @see \Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection::buildEntityQuery()
+    $edit = [
+      'name' => 'class',
+      'og_group_content_bundle' => 1,
+      'og_target_type' => 'node',
+      'og_target_bundles[]' => [],
+    ];
+    $this->drupalPostForm('admin/structure/types/manage/class', $edit, t('Save content type'));
+    $this->assertTargetBundles(NULL, 'When the target bundle field is cleared from all values, it takes on the value NULL.');
+  }
+
+  /**
+   * Checks whether the target bundles in the group content are as expected.
+   *
+   * @param array|NULL $expected
+   *   The expected value for the target bundles.
+   * @param $message
+   *   The message to display with the assertion.
+   */
+  protected function assertTargetBundles($expected, $message) {
+    /** @var EntityFieldManagerInterface $entity_field_manager */
+    $entity_field_manager = $this->container->get('entity_field.manager');
+    $entity_field_manager->clearCachedFieldDefinitions();
+    $field_definitions = $entity_field_manager->getFieldDefinitions('node', 'class');
+    $settings = $field_definitions['og_group_ref']->getSetting('handler_settings');
+    $this->assertIdentical($settings['target_bundles'], $expected, $message);
   }
 
 }

--- a/og_ui/tests/src/Functional/BundleFormAlterTest.php
+++ b/og_ui/tests/src/Functional/BundleFormAlterTest.php
@@ -8,14 +8,19 @@
 namespace Drupal\og_ui\Tests;
 
 use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\simpletest\WebTestBase;
+use Drupal\KernelTests\AssertLegacyTrait;
+use Drupal\simpletest\AssertContentTrait;
+use Drupal\simpletest\BrowserTestBase;
 
 /**
  * Test making a bundle a group and a group content.
  *
  * @group og
  */
-class BundleFormAlterTest extends WebTestBase {
+class BundleFormAlterTest extends BrowserTestBase {
+
+  use AssertContentTrait;
+  use AssertLegacyTrait;
 
   /**
    * Modules to enable.
@@ -32,7 +37,8 @@ class BundleFormAlterTest extends WebTestBase {
       'type' => 'school',
       'og_is_group' => 1,
     ];
-    $this->drupalPostForm('admin/structure/types/add', $edit, t('Save content type'));
+    $this->drupalGet('admin/structure/types/add');
+    $this->submitForm($edit, t('Save content type'));
     $edit = [
       'name' => 'class',
       'type' => 'class',
@@ -40,8 +46,9 @@ class BundleFormAlterTest extends WebTestBase {
       'og_target_type' => 'node',
       'og_target_bundles[]' => ['school'],
     ];
-    $this->drupalPostForm('admin/structure/types/add', $edit, t('Save content type'));
-    $this->drupalGet('admin/structure/types/manage/class');
+    $this->drupalGet('admin/structure/types/add');
+    $this->submitForm($edit, t('Save content type'));
+    $this->content = $this->drupalGet('admin/structure/types/manage/class');
     $this->assertOptionSelected('edit-og-target-bundles', 'school');
     $this->assertTargetBundles(['school' => 'school'], 'The target bundles are set to the "school" bundle.');
 
@@ -56,7 +63,8 @@ class BundleFormAlterTest extends WebTestBase {
       'og_target_type' => 'node',
       'og_target_bundles[]' => [],
     ];
-    $this->drupalPostForm('admin/structure/types/manage/class', $edit, t('Save content type'));
+    $this->drupalGet('admin/structure/types/manage/class');
+    $this->submitForm($edit, t('Save content type'));
     $this->assertTargetBundles(NULL, 'When the target bundle field is cleared from all values, it takes on the value NULL.');
   }
 
@@ -74,7 +82,7 @@ class BundleFormAlterTest extends WebTestBase {
     $entity_field_manager->clearCachedFieldDefinitions();
     $field_definitions = $entity_field_manager->getFieldDefinitions('node', 'class');
     $settings = $field_definitions['og_group_ref']->getSetting('handler_settings');
-    $this->assertIdentical($settings['target_bundles'], $expected, $message);
+    $this->assertEquals($expected, $settings['target_bundles'], $message);
   }
 
 }


### PR DESCRIPTION
When you create a group content type, and unselect all the options in the "Target bundles" select list then this error occurs when you try to save a group content entity that refers a group:

> TypeError: Argument 1 passed to Drupal\Core\Field\Plugin\Field\FieldWidget\EntityReferenceAutocompleteWidget::errorElement() must be of the type array, null given, called in /core/lib/Drupal/Core/Field/WidgetBase.php on line 444 in Drupal\Core\Field\Plugin\Field\FieldWidget\EntityReferenceAutocompleteWidget->errorElement() (line 122 of core/lib/Drupal/Core/Field/Plugin/Field/FieldWidget/EntityReferenceAutocompleteWidget.php).

This happens because the field settings for the group audience field are saved as an empty array instead of NULL. Entity references consider an empty array to mean that no bundles can be referenced.

This is from the documentation of `\Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection::buildEntityQuery()`:

```
// If 'target_bundles' is NULL, all bundles are referenceable, no further
// conditions are needed.
...
// If 'target_bundles' is an empty array, no bundle is referenceable,
// force the query to never return anything and bail out early.
```
