### PR TITLE
Make the group audience field visible in the form display

### DIFF
--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -94,3 +94,17 @@ og.og_role.*:
       sequence:
         type: string
         label: 'Permission'
+
+field.widget.settings.og_complex:
+  type: mapping
+  label: 'OG complex widget display format settings'
+  mapping:
+    match_operator:
+      type: string
+      label: 'Autocomplete matching'
+    size:
+      type: integer
+      label: 'Size of textfield'
+    placeholder:
+      type: label
+      label: 'Placeholder'

--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -97,7 +97,7 @@ og.og_role.*:
 
 field.widget.settings.og_complex:
   type: mapping
-  label: 'OG complex widget display format settings'
+  label: 'OG Group Audience field widget'
   mapping:
     match_operator:
       type: string

--- a/src/Og.php
+++ b/src/Og.php
@@ -9,6 +9,7 @@ namespace Drupal\og;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -81,6 +82,19 @@ class Og {
       // @todo: Verify this is still needed here.
       static::invalidateCache();
     }
+
+    // Make the field visible in the default form display.
+    /** @var EntityFormDisplayInterface $form_display */
+    $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load("$entity_type.$bundle.default");
+    $widget = $form_display->getComponent($plugin_id);
+    $widget['type'] = 'og_complex';
+    $widget['settings'] = [
+      'match_operator' => 'CONTAINS',
+      'size' => 60,
+      'placeholder' => '',
+    ];
+    $form_display->setComponent($plugin_id, $widget);
+    $form_display->save();
 
     return $field_definition;
   }

--- a/src/Og.php
+++ b/src/Og.php
@@ -59,7 +59,7 @@ class Og {
 
     // Get the field definition and add the entity info to it. By doing so
     // we validate the the field can be attached to the entity. For example,
-    // the OG accesss module's field can be attached only to node entities, so
+    // the OG access module's field can be attached only to node entities, so
     // any other entity will throw an exception.
     /** @var \Drupal\og\OgFieldBase $og_field */
     $og_field = static::getFieldBaseDefinition($plugin_id)
@@ -71,7 +71,6 @@ class Og {
       $field_storage_config = NestedArray::mergeDeep($og_field->getFieldStorageConfigBaseDefinition(), $settings['field_storage_config']);
       FieldStorageConfig::create($field_storage_config)->save();
     }
-
 
     if (!$field_definition = FieldConfig::loadByName($entity_type, $bundle, $field_name)) {
       $field_config = NestedArray::mergeDeep($og_field->getFieldConfigBaseDefinition(), $settings['field_config']);

--- a/src/Og.php
+++ b/src/Og.php
@@ -86,6 +86,20 @@ class Og {
     // Make the field visible in the default form display.
     /** @var EntityFormDisplayInterface $form_display */
     $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load("$entity_type.$bundle.default");
+
+    // If not found, create a fresh form display object. This is by design,
+    // configuration entries are only created when an entity form display is
+    // explicitly configured and saved.
+    // @see entity_get_form_display()
+    if (!$form_display) {
+      $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->create([
+        'targetEntityType' => $entity_type,
+        'bundle' => $bundle,
+        'mode' => 'default',
+        'status' => TRUE,
+      ]);
+    }
+
     $widget = $form_display->getComponent($plugin_id);
     $widget['type'] = 'og_complex';
     $widget['settings'] = [
@@ -93,6 +107,7 @@ class Og {
       'size' => 60,
       'placeholder' => '',
     ];
+
     $form_display->setComponent($plugin_id, $widget);
     $form_display->save();
 


### PR DESCRIPTION
This is a fix for https://github.com/amitaibu/og/issues/144.

When the group audience field is added to a bundle (e.g. by creating a group content type) then the field is hidden in the form display. Most of the time the site administrators will want to have this field visible, because it is needed to select the group the content should belong to.
## How to test manually
- Enable the `field_ui`, `node`, `og` and `og_ui` modules.
- Create a new content type at `admin/structure/types/add`. Name it "School", and select it to be a "Group" in the "Organic Groups" vertical tab.
- Create a second content type at `admin/structure/types/add`. Name it "Class".Select it to be "Group content" in the "Organic Groups" vertical tab, and set the target bundle to "School".
- Now create a new node of type "Class" at `node/add/class`.
- You should see the Group Audience field.
