### PR TITLE
AJAX selection of target entity types and bundles is broken on the bundle entity form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ before_script:
   - travis_retry git clone --branch $DRUPAL_CORE --depth 1 https://git.drupal.org/project/drupal.git
   - cd drupal
 
+  # Install Composer dependencies on 8.1.x.
+  - test ${DRUPAL_CORE} == "8.1.x" && composer self-update && composer install || true
+
   # Reference OG in the Drupal site.
   - ln -s $TESTDIR modules/og
 

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -82,13 +82,13 @@ class BundleFormAlter {
     // Example: node.
     $this->entityTypeId = $this->definition->getBundleOf();
 
-    $form['og'] = array(
+    $form['og'] = [
       '#type' => 'details',
       '#title' => t('Organic groups'),
       '#collapsible' => TRUE,
       '#group' => 'additional_settings',
       '#description' => t('This bundle may serve as a group, may belong to a group, or may not participate in OG at all.'),
-    );
+    ];
   }
 
   /**
@@ -103,12 +103,12 @@ class BundleFormAlter {
         '%bundle' => Unicode::lcfirst($this->bundleLabel),
       ]);
     }
-    $form['og']['og_is_group'] = array(
+    $form['og']['og_is_group'] = [
       '#type' => 'checkbox',
       '#title' => t('Group'),
       '#default_value' => Og::isGroup($this->entityTypeId, $this->bundle),
       '#description' => $description,
-    );
+    ];
   }
 
   /**
@@ -150,35 +150,35 @@ class BundleFormAlter {
       $description = t('There are no group bundles defined.');
     }
 
-    $form['og']['og_group_content_bundle'] = array(
+    $form['og']['og_group_content_bundle'] = [
       '#type' => 'checkbox',
       '#title' => t('Group content'),
       '#default_value' => $is_group_content,
       '#description' => $description,
-    );
+    ];
 
     if ($target_types) {
       // Don't show the settings, as there might be multiple OG audience fields
       // in the same bundle.
-      $form['og']['og_target_type'] = array(
+      $form['og']['og_target_type'] = [
         '#type' => 'select',
         '#title' => t('Target type'),
         '#options' => $target_types,
         '#default_value' => $target_type_default,
         '#description' => t('The entity type that can be referenced through this field.'),
-        '#ajax' => array(
+        '#ajax' => [
           'callback' => [$this, 'ajaxCallback'],
           'wrapper' => 'og-settings-wrapper',
-        ),
-        '#states' => array(
-          'visible' => array(
-            ':input[name="og_group_content_bundle"]' => array('checked' => TRUE),
-          ),
-        ),
-      );
+        ],
+        '#states' => [
+          'visible' => [
+            ':input[name="og_group_content_bundle"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
 
       // Get the bundles that are acting as group.
-      $form['og']['og_target_bundles'] = array(
+      $form['og']['og_target_bundles'] = [
         '#prefix' => '<div id="og-settings-wrapper">',
         '#suffix' => '</div>',
         '#type' => 'select',
@@ -187,12 +187,12 @@ class BundleFormAlter {
         '#default_value' => !empty($handler_settings['target_bundles']) ? $handler_settings['target_bundles'] : NULL,
         '#multiple' => TRUE,
         '#description' => t('The bundles of the entity type that can be referenced. Optional, leave empty for all bundles.'),
-        '#states' => array(
-          'visible' => array(
-            ':input[name="og_group_content_bundle"]' => array('checked' => TRUE),
-          ),
-        ),
-      );
+        '#states' => [
+          'visible' => [
+            ':input[name="og_group_content_bundle"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
       $form['#validate'][] = [get_class($this), 'validateTargetBundleElement'];
     }
     else {

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -64,7 +64,7 @@ class BundleFormAlter {
    * AJAX callback displaying the target bundles select box.
    */
   public function ajaxCallback(array $form, FormStateInterface $form_state) {
-    return $form['og']['target_bundles'];
+    return $form['og']['og_target_bundles'];
   }
 
   /**
@@ -142,6 +142,10 @@ class BundleFormAlter {
       // back to the first entity type that was returned.
       reset($target_types);
       $target_type_default = isset($handler_settings['target_type']) ? $handler_settings['target_type'] : key($target_types);
+
+      // If the target type was set using AJAX, use that instead of the default.
+      $ajax_value = $form_state->getValue('og_target_type');
+      $target_type_default = $ajax_value ? $ajax_value : $target_type_default;
 
       $form['og']['og_target_type'] = [
         '#type' => 'select',

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -158,8 +158,6 @@ class BundleFormAlter {
     ];
 
     if ($target_types) {
-      // Don't show the settings, as there might be multiple OG audience fields
-      // in the same bundle.
       $form['og']['og_target_type'] = [
         '#type' => 'select',
         '#title' => t('Target type'),
@@ -196,6 +194,8 @@ class BundleFormAlter {
       $form['#validate'][] = [get_class($this), 'validateTargetBundleElement'];
     }
     else {
+      // Don't show the settings, as there might be multiple OG audience fields
+      // in the same bundle.
       $form['og']['og_group_content_bundle']['#disabled'] = TRUE;
     }
   }

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -63,7 +63,7 @@ class BundleFormAlter {
   /**
    * AJAX callback displaying the target bundles select box.
    */
-  public function ajaxCallback(array $form, array &$form_state) {
+  public function ajaxCallback(array $form, FormStateInterface $form_state) {
     return $form['og']['target_bundles'];
   }
 
@@ -73,7 +73,7 @@ class BundleFormAlter {
    * @param array $form
    * @param $form_state
    */
-  protected function prepare(array &$form, $form_state) {
+  protected function prepare(array &$form, FormStateInterface $form_state) {
     // Example: article.
     $this->bundle = $this->entity->id();
     // Example: Article.
@@ -94,7 +94,7 @@ class BundleFormAlter {
   /**
    * Adds the "is group?" checkbox.
    */
-  protected function addGroupType(array &$form, $form_state) {
+  protected function addGroupType(array &$form, FormStateInterface $form_state) {
     if ($this->entity->isNew()) {
       $description = t('Every entity in this bundle is a group which can contain entities and can have members.');
     }
@@ -114,7 +114,7 @@ class BundleFormAlter {
   /**
    * Adds the "is group content?" checkbox and target settings elements.
    */
-  protected function addGroupContent(array &$form, $form_state) {
+  protected function addGroupContent(array &$form, FormStateInterface $form_state) {
     $is_group_content = Og::isGroupContent($this->entityTypeId, $this->bundle);
 
     $target_type_default = FALSE;


### PR DESCRIPTION
The ajax selection of target entity types and bundles for group content is broken:

![broken-ajax](https://cloud.githubusercontent.com/assets/442924/13716825/1be0c0a6-e7e6-11e5-91d2-17cbad4a7131.png)

When you select a different entity type, the bundles do not update. The bundles from the first entity type are always displayed. When the form is saved after changing the entity type, the configuration is invalid.
