### PR TITLE
Support for uri enti

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ before_script:
   - travis_retry git clone --branch $DRUPAL_CORE --depth 1 https://git.drupal.org/project/drupal.git
   - cd drupal
 
+  # Install Composer dependencies on 8.1.x.
+  - test ${DRUPAL_CORE} == "8.1.x" && composer self-update && composer install || true
+
   # Reference OG in the Drupal site.
   - ln -s $TESTDIR modules/og
 

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -320,7 +320,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
       // Matches the entity label and ID. E.g. 'Label (123)'. The entity ID will
       // be captured in it's own group, with the key 'id'.
-      preg_match("|.+\((?<id>[!@#$%\^\&\*:/_-\w.]+)\)|", $value['target_id']['#value'], $matches);
+      preg_match("|.+\((?<id>[!@#$%\^\&\*:/-\w.]+)\)|", $value['target_id']['#value'], $matches);
 
       if (!empty($matches['id'])) {
         $values[] = [

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -320,7 +320,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
       // Matches the entity label and ID. E.g. 'Label (123)'. The entity ID will
       // be captured in it's own group, with the key 'id'.
-      preg_match("|.+\((?<id>[\w.]+)\)|", $value['target_id']['#value'], $matches);
+      preg_match("|.+\((?<id>[!@#$%\^\&\*:/_-\w.]+)\)|", $value['target_id']['#value'], $matches);
 
       if (!empty($matches['id'])) {
         $values[] = [


### PR DESCRIPTION
This is simply to support more special characters in entity id. In my case, URIs were not supported as ':' and '/' characters were causing preg_match to return no results.
Added some more in case someone else has different entity ids.
Still this preg_match fails if there are parenthesis symbols in the entity id. I don't know if drupal allows it, but if it does, maybe a different approach could be used in the future for this.
