### PR TITLE
Avoid doing a needless query that will always return an empty result set

### DIFF
--- a/src/Og.php
+++ b/src/Og.php
@@ -243,6 +243,10 @@ class Og {
         return $value['target_id'];
       }, $entity->get($field->getName())->getValue());
 
+      if (empty($target_ids)) {
+        continue;
+      }
+
       // Query the database to get the actual list of groups. The target IDs may
       // contain groups that no longer exist. Entity reference doesn't clean up
       // orphaned target IDs.


### PR DESCRIPTION
If there are no target groups in `Og::getGroupIds()` we don't need to query the database since it will always return empty anyway. This will save milliseconds!
