### PR TITLE
Fix removal of orphans by the Simple plugin

### DIFF
--- a/src/Plugin/OgDeleteOrphans/Simple.php
+++ b/src/Plugin/OgDeleteOrphans/Simple.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\og\Plugin\OgDeleteOrphans;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\og\OgDeleteOrphansBase;
 
 /**
@@ -14,6 +15,15 @@ use Drupal\og\OgDeleteOrphansBase;
  * )
  */
 class Simple extends OgDeleteOrphansBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(EntityInterface $entity) {
+    parent::register($entity);
+    // Delete the orphans on the fly.
+    $this->process();
+  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
My colleague @sandervd discovered that the Simple plugin is not actually deleting the orphans. The processing of the orphans is not invoked after they are registered.
