### PR TITLE
Roles + permissions overview

### DIFF
--- a/og_ui/og_ui.links.menu.yml
+++ b/og_ui/og_ui.links.menu.yml
@@ -11,3 +11,19 @@ og_ui.settings:
   parent: og_ui.admin_index
   description: 'Administer OG settings.'
   route_name: og_ui.settings
+
+og_ui.roles_overview:
+  title: 'OG roles'
+  parent: og_ui.admin_index
+  description: 'Administer OG roles.'
+  route_name: og_ui.roles_permissions_overview
+  route_parameters:
+    type: 'roles'
+
+og_ui.permissions_overview:
+  title: 'OG permissions'
+  parent: og_ui.admin_index
+  description: 'Administer OG permissions.'
+  route_name: og_ui.roles_permissions_overview
+  route_parameters:
+    type: 'permissions'

--- a/og_ui/og_ui.routing.yml
+++ b/og_ui/og_ui.routing.yml
@@ -21,7 +21,6 @@ og_ui.roles_permissions_overview:
   defaults:
     _controller: '\Drupal\og_ui\Controller\OgUiController::rolesPermissionsOverviewPage'
     _title_callback: '\Drupal\og_ui\Controller\OgUiController::rolesPermissionsOverviewTitleCallback'
-    type: 'roles'
   requirements:
     _permission: 'administer group'
     type: '^(roles|permissions)$'

--- a/og_ui/og_ui.routing.yml
+++ b/og_ui/og_ui.routing.yml
@@ -15,3 +15,29 @@ og_ui.settings:
     _title: 'OG settings'
   requirements:
     _permission: 'administer group'
+
+og_ui.roles_permissions_overview:
+  path: 'admin/config/group/{type}'
+  defaults:
+    _controller: '\Drupal\og_ui\Controller\OgUiController::rolesPermissionsOverviewPage'
+    _title_callback: '\Drupal\og_ui\Controller\OgUiController::rolesPermissionsOverviewTitleCallback'
+    type: 'roles'
+  requirements:
+    _permission: 'administer group'
+    type: '^(roles|permissions)$'
+
+og_ui.roles_form:
+  path: 'admin/config/group/roles/{entity_type}/{bundle}'
+  defaults:
+    _form: '\Drupal\og_ui\Form\OgRolesForm'
+    _title: '@todo - create title callback'
+  requirements:
+    _permission: 'administer group'
+
+og_ui.permissions_form:
+  path: 'admin/config/group/permissions/{entity_type}/{bundle}'
+  defaults:
+    _form: '\Drupal\og_ui\Form\OgPermissionsForm'
+    _title: '@todo - create title callback'
+  requirements:
+    _permission: 'administer group'

--- a/og_ui/src/Controller/OgUiController.php
+++ b/og_ui/src/Controller/OgUiController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\og_ui\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Link;
+use Drupal\og\GroupManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class OgUiController extends ControllerBase {
+
+  /**
+   * The OG group manager.
+   *
+   * @var \Drupal\og\GroupManager
+   */
+  protected $groupManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+  
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * Constructs a OgUiController object.
+   *
+   * @param \Drupal\og\GroupManager $group_manager
+   *   The OG group manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
+   */
+  public function __construct(GroupManager $group_manager, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+    $this->groupManager = $group_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('og.group.manager'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info')
+    );
+  }
+  
+  /**
+   * Returns the overview of OG roles and permissions.
+   *
+   * @param string $type
+   *   The type of overview, either 'roles' or 'permissions'.
+   *
+   * @return array
+   *   The overview as a render array.
+   */
+  public function rolesPermissionsOverviewPage($type) {
+    $action = $type === 'roles' ? t('Edit roles') : t('Edit permissions');
+    $header = [t('Group type'), t('Operations')];
+    $rows = [];
+
+    foreach ($this->groupManager->getAllGroupBundles() as $entity_type => $bundles) {
+      $definition = $this->entityTypeManager->getDefinition($entity_type);
+      $bundle_info = $this->entityTypeBundleInfo->getBundleInfo($entity_type);
+      foreach ($bundles as $bundle) {
+        $rows[] = [
+          [
+            'data' => $definition->getLabel() . ' - ' . $bundle_info[$bundle]['label'],
+          ],
+          [
+            'data' => Link::createFromRoute($action, 'og_ui.' . $type . '_form', [
+              'entity_type' => $entity_type,
+              'bundle' => $bundle,
+            ]),
+          ],
+        ];
+      }
+    }
+
+    $build['roles_table'] = [
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#empty' => $this->t('No group types available.'),
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Title callback for rolesPermissionsOverviewPage.
+   *
+   * @param string $type
+   *   The type of overview, either 'roles' or 'permissions'.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   */
+  public function rolesPermissionsOverviewTitleCallback($type) {
+    return $this->t('OG @type overview', ['@type' => $type]);
+  }
+  
+}

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -75,6 +75,8 @@ class GroupManager {
    * Get all group bundles keyed by entity type.
    *
    * @return array
+   *   An associative array, keyed by entity type, each value an indexed array
+   *   of bundle IDs.
    */
   public function getAllGroupBundles($entity_type = NULL) {
     return !empty($this->groupMap[$entity_type]) ? $this->groupMap[$entity_type] : $this->groupMap;


### PR DESCRIPTION
Here's a simple PR that implements the roles + permissions overview at `/admin/config/group/roles` and `/admin/config/group/permissions`.

The forms to manage the roles and permissions are not part of this.
