### PR TITLE
Notice thrown in bundle edit form after removing last group

### DIFF
--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -110,6 +110,11 @@ class GroupManager {
 
       if ($search_key !== FALSE) {
         unset($groups[$entity_type_id][$search_key]);
+        // If the last group of this entity type is removed, also remove the
+        // empty container.
+        if (empty($groups[$entity_type_id])) {
+          unset($groups[$entity_type_id]);
+        }
       }
 
       // Only update and refresh the map if a key was found and unset.

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -112,12 +112,10 @@ class GroupManager {
 
       if ($search_key !== FALSE) {
         unset($groups[$entity_type_id][$search_key]);
-        // If the last group of this entity type is removed, also remove the
-        // empty container.
-        if (empty($groups[$entity_type_id])) {
-          unset($groups[$entity_type_id]);
-        }
       }
+
+      // Clean up entity types that have become empty.
+      $groups = array_filter($groups);
 
       // Only update and refresh the map if a key was found and unset.
       $editable->set('groups', $groups);


### PR DESCRIPTION
I'm getting a notice in the bundle edit form after adding a single group type and then removing the group type again:

> Notice: Undefined index: rdf_entity in Drupal\og_ui\BundleFormAlter->addGroupContent() (line 173 of modules/contrib/og/og_ui/src/BundleFormAlter.php).

This happens because when the last group is removed for a given entity type in `GroupManager::removeGroup()` an empty array container is left behind. This fools the calling code in thinking that the entity type still has some groups in it.
