### PR TITLE
Fatal error when re-creating a group

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -78,7 +78,7 @@ function og_ui_entity_type_save(EntityInterface $entity) {
   // Change the field target type and bundle.
   if ($field_storage = FieldStorageConfig::loadByName($entity_type_id, OgGroupAudienceHelper::DEFAULT_FIELD)) {
     $target_type = $field_storage->getSetting('target_type');
-    if ($entity->og_target_type !== $target_type) {
+    if (!empty($entity->og_target_type) && $entity->og_target_type !== $target_type) {
       // @todo It's probably not possible to change the field storage after the
       //   field has data. We should disable this option in the UI.
       $field_storage->setSetting('target_type', $entity->og_target_type);


### PR DESCRIPTION
When I only have one group type, then remove it, then try to add it again in the bundle edit form I get a fatal error:

```
Drupal\Component\Plugin\Exception\PluginNotFoundException: The "" entity type does not exist. in Drupal\Core\Entity\EntityTypeManager->getDefinition() (line 125 of core/lib/Drupal/Core/Entity/EntityTypeManager.php).
Drupal\Core\Entity\EntityManager->getDefinition(NULL) (Line: 433)
Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem::calculateStorageDependencies(Object) (Line: 344)
Drupal\field\Entity\FieldStorageConfig->calculateDependencies() (Line: 346)
Drupal\Core\Config\Entity\ConfigEntityBase->preSave(Object) (Line: 292)
Drupal\field\Entity\FieldStorageConfig->preSave(Object) (Line: 434)
Drupal\Core\Entity\EntityStorageBase->doPreSave(Object) (Line: 389)
Drupal\Core\Entity\EntityStorageBase->save(Object) (Line: 259)
Drupal\Core\Config\Entity\ConfigEntityStorage->save(Object) (Line: 358)
Drupal\Core\Entity\Entity->save() (Line: 637)
Drupal\Core\Config\Entity\ConfigEntityBase->save() (Line: 85)
og_ui_entity_type_save(Object) (Line: 38)
og_ui_entity_update(Object, 'rdf_type')
call_user_func_array('og_ui_entity_update', Array) (Line: 402)
Drupal\Core\Extension\ModuleHandler->invokeAll('entity_update', Array) (Line: 371)
Drupal\Core\Config\Entity\ConfigEntityStorage->invokeHook('update', Object) (Line: 470)
Drupal\Core\Entity\EntityStorageBase->doPostSave(Object, 1) (Line: 395)
Drupal\Core\Entity\EntityStorageBase->save(Object) (Line: 259)
Drupal\Core\Config\Entity\ConfigEntityStorage->save(Object) (Line: 358)
Drupal\Core\Entity\Entity->save() (Line: 637)
Drupal\Core\Config\Entity\ConfigEntityBase->save() (Line: 99)
Drupal\rdf_entity\Form\RdfTypeForm->save(Array, Object)
call_user_func_array(Array, Array) (Line: 111)
Drupal\Core\Form\FormSubmitter->executeSubmitHandlers(Array, Object) (Line: 51)
...
```

This happens because the base field will still be present on the entity, but since there is no group to reference the `$entity->og_target_type` property will be empty. `og_ui_entity_type_save()` does not check this and proceeds to try saving an empty target type in the field storage.
