### PR TITLE
Improve variable naming and documentation of getAllGroupAudienceFields()

### DIFF
--- a/src/OgGroupAudienceHelper.php
+++ b/src/OgGroupAudienceHelper.php
@@ -129,18 +129,20 @@ class OgGroupAudienceHelper {
   }
 
   /**
-   * Return all the group audience fields of a certain bundle.
+   * Returns all the group audience fields of a certain bundle.
    *
    * @param string $group_content_entity_type_id
-   *   The entity type.
+   *   The entity type ID of the group content for which to return audience
+   *   fields.
    * @param string  $group_content_bundle_id
-   *   The bundle name to be checked.
+   *   The bundle name of the group content for which to return audience fields.
    * @param string $group_entity_type_id
-   *   Filter list to only include fields referencing a specific group type.
+   *   Filter list to only include fields referencing a specific group type. If
+   *   omitted, all fields will be returned.
    * @param string $group_bundle_id
    *   Filter list to only include fields referencing a specific group bundle.
    *   Fields that do not specify any bundle restrictions at all are also
-   *   included.
+   *   included. If omitted, the results will not be filtered by group bundle.
    *
    * @return \Drupal\Core\Field\FieldDefinitionInterface[]
    *   An array of field definitions, keyed by field name; Or an empty array if
@@ -154,6 +156,8 @@ class OgGroupAudienceHelper {
       // This entity type is not fieldable.
       return [];
     }
+
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $field_definitions */
     $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($group_content_entity_type_id, $group_content_bundle_id);
 
     foreach ($field_definitions as $field_definition) {

--- a/src/OgGroupAudienceHelper.php
+++ b/src/OgGroupAudienceHelper.php
@@ -131,13 +131,13 @@ class OgGroupAudienceHelper {
   /**
    * Return all the group audience fields of a certain bundle.
    *
-   * @param string $entity_type_id
+   * @param string $group_content_entity_type_id
    *   The entity type.
-   * @param string  $bundle
+   * @param string  $group_content_bundle_id
    *   The bundle name to be checked.
-   * @param string $group_type_id
+   * @param string $group_entity_type_id
    *   Filter list to only include fields referencing a specific group type.
-   * @param string $group_bundle
+   * @param string $group_bundle_id
    *   Filter list to only include fields referencing a specific group bundle.
    *   Fields that do not specify any bundle restrictions at all are also
    *   included.
@@ -146,15 +146,15 @@ class OgGroupAudienceHelper {
    *   An array of field definitions, keyed by field name; Or an empty array if
    *   none found.
    */
-  public static function getAllGroupAudienceFields($entity_type_id, $bundle, $group_type_id = NULL, $group_bundle = NULL) {
+  public static function getAllGroupAudienceFields($group_content_entity_type_id, $group_content_bundle_id, $group_entity_type_id = NULL, $group_bundle_id = NULL) {
     $return = [];
-    $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+    $entity_type = \Drupal::entityTypeManager()->getDefinition($group_content_entity_type_id);
 
     if (!$entity_type->isSubclassOf(FieldableEntityInterface::class)) {
       // This entity type is not fieldable.
       return [];
     }
-    $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type_id, $bundle);
+    $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($group_content_entity_type_id, $group_content_bundle_id);
 
     foreach ($field_definitions as $field_definition) {
       if (!static::isGroupAudienceField($field_definition)) {
@@ -164,14 +164,14 @@ class OgGroupAudienceHelper {
 
       $target_type = $field_definition->getFieldStorageDefinition()->getSetting('target_type');
 
-      if (isset($group_type_id) && $target_type != $group_type_id) {
+      if (isset($group_entity_type_id) && $target_type != $group_entity_type_id) {
         // Field doesn't reference this group type.
         continue;
       }
 
       $handler_settings = $field_definition->getSetting('handler_settings');
 
-      if (isset($group_bundle) && !empty($handler_settings['target_bundles']) && !in_array($group_bundle, $handler_settings['target_bundles'])) {
+      if (isset($group_bundle_id) && !empty($handler_settings['target_bundles']) && !in_array($group_bundle_id, $handler_settings['target_bundles'])) {
         continue;
       }
 

--- a/src/OgGroupAudienceHelper.php
+++ b/src/OgGroupAudienceHelper.php
@@ -134,7 +134,7 @@ class OgGroupAudienceHelper {
    * @param string $group_content_entity_type_id
    *   The entity type ID of the group content for which to return audience
    *   fields.
-   * @param string  $group_content_bundle_id
+   * @param string $group_content_bundle_id
    *   The bundle name of the group content for which to return audience fields.
    * @param string $group_entity_type_id
    *   Filter list to only include fields referencing a specific group type. If


### PR DESCRIPTION
Small improvement to `OgGroupAudienceHelper::getAllGroupAudienceFields()`. I have renamed the variables so they are now completely unambiguous, and have extended the documentation a bit.
