### PR TITLE
Provide methods to retrieve group bundles by group content bundles and vice versa

### DIFF
--- a/og.services.yml
+++ b/og.services.yml
@@ -1,7 +1,7 @@
 services:
   og.group.manager:
     class: Drupal\og\GroupManager
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@entity_type.bundle.info']
   og.permissions:
     class: Drupal\og\OgPermissionHandler
     arguments: ['@module_handler', '@string_translation', '@controller_resolver']

--- a/og.services.yml
+++ b/og.services.yml
@@ -1,7 +1,7 @@
 services:
   og.group.manager:
     class: Drupal\og\GroupManager
-    arguments: ['@config.factory', '@entity_type.bundle.info']
+    arguments: ['@config.factory', '@entity_type.bundle.info', '@state']
   og.permissions:
     class: Drupal\og\OgPermissionHandler
     arguments: ['@module_handler', '@string_translation', '@controller_resolver']

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -8,9 +8,27 @@
 namespace Drupal\og;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\og\Entity\OgRole;
 
 /**
  * A manager to keep track of which entity type/bundles are OG group enabled.
+ *
+ * @property array $groupRelationMap
+ *   A map of group and group content relations. This is an associative array
+ *   representing group and group content relations, in the following format:
+ *   @code
+ *   [
+ *     'group_entity_type_id' => [
+ *       'group_bundle_id' => [
+ *         'group_content_entity_type_id' => [
+ *           'group_content_bundle_id',
+ *         ],
+ *       ],
+ *     ],
+ *   ]
+ *   @endcode
  */
 class GroupManager {
 
@@ -36,6 +54,13 @@ class GroupManager {
   protected $configFactory;
 
   /**
+   * The service providing information about bundles.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
    * A map of entity types and bundles.
    *
    * @var array
@@ -44,10 +69,38 @@ class GroupManager {
 
   /**
    * Constructs an GroupManager object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The service providing information about bundles.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->configFactory = $config_factory;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->refreshGroupMap();
+  }
+
+  /**
+   * Magic getter.
+   *
+   * @param string $property
+   *   The property being gotten.
+   *
+   * @return mixed
+   *   The property value.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when an invalid property is passed.
+   */
+  public function __get($property) {
+    // Computing the group relation map is expensive, do it only on demand.
+    if ($property === 'groupRelationMap') {
+      $this->refreshGroupRelationMap();
+      return $this->groupRelationMap;
+    }
+
+    throw new \InvalidArgumentException(__CLASS__ . '->' . $property . ' is undefined.');
   }
 
   /**
@@ -78,6 +131,59 @@ class GroupManager {
    */
   public function getAllGroupBundles($entity_type = NULL) {
     return !empty($this->groupMap[$entity_type]) ? $this->groupMap[$entity_type] : $this->groupMap;
+  }
+
+  /**
+   * Returns all group bundles that are referenced by the given group content.
+   *
+   * @param string $group_content_entity_type_id
+   *   The entity type ID of the group content type for which to return
+   *   associated group bundle IDs.
+   * @param string $group_content_bundle_id
+   *   The bundle ID of the group content type for which to return associated
+   *   group bundle IDs.
+   *
+   * @return array
+   *   An array of group bundle IDs, keyed by group entity type ID.
+   */
+  public function getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id) {
+    $bundles = [];
+
+    foreach (OgGroupAudienceHelper::getAllGroupAudienceFields($group_content_entity_type_id, $group_content_bundle_id) as $field) {
+      $group_entity_type_id = $field->getSetting('target_type');
+      $handler_settings = $field->getSetting('handler_settings');
+      $group_bundle_ids = !empty($handler_settings['target_bundles']) ? $handler_settings['target_bundles'] : [];
+
+      // If the group bundles are empty, it means that all bundles are
+      // referenced.
+      if (empty($group_bundle_ids)) {
+        $group_bundle_ids = $this->groupMap[$group_entity_type_id];
+      }
+
+      foreach ($group_bundle_ids as $group_bundle_id) {
+        $bundles[$group_entity_type_id][$group_bundle_id] = $group_bundle_id;
+      }
+    }
+
+    return $bundles;
+  }
+
+  /**
+   * Returns group content bundles that are referencing the given group content.
+   *
+   * @param string $group_entity_type_id
+   *   The entity type ID of the group type for which to return associated group
+   *   content bundle IDs.
+   * @param string $group_bundle_id
+   *   The bundle ID of the group type for which to return associated group
+   *   content bundle IDs.
+   *
+   * @return array
+   *   An array of group content bundle IDs, keyed by group content entity type
+   *   ID.
+   */
+  public function getGroupContentBundleIdsByGroupBundle($group_entity_type_id, $group_bundle_id) {
+    return isset($this->groupRelationMap[$group_entity_type_id][$group_bundle_id]) ? $this->groupRelationMap[$group_entity_type_id][$group_bundle_id] : [];
   }
 
   /**
@@ -126,7 +232,25 @@ class GroupManager {
    * Refreshes the groupMap property with currently configured groups.
    */
   protected function refreshGroupMap() {
-    $this->groupMap = $this->configFactory->get(static::SETTINGS_CONFIG_KEY)->get(static::GROUPS_CONFIG_KEY);
+    $group_map = $this->configFactory->get(static::SETTINGS_CONFIG_KEY)->get(static::GROUPS_CONFIG_KEY);
+    $this->groupMap = !empty($group_map) ? $group_map : [];
+  }
+
+  /**
+   * Builds the map of relations between group types and group content types.
+   */
+  protected function refreshGroupRelationMap() {
+    $this->groupRelationMap = [];
+
+    foreach ($this->entityTypeBundleInfo->getAllBundleInfo() as $group_content_entity_type_id => $bundles) {
+      foreach ($bundles as $group_content_bundle_id => $bundle_info) {
+        foreach ($this->getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id) as $group_entity_type_id => $group_bundle_ids) {
+          foreach ($group_bundle_ids as $group_bundle_id) {
+            $this->groupRelationMap[$group_entity_type_id][$group_bundle_id][$group_content_entity_type_id][$group_content_bundle_id] = $group_content_bundle_id;
+          }
+        }
+      }
+    }
   }
 
 }

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -9,8 +9,6 @@ namespace Drupal\og;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\og\Entity\OgRole;
 
 /**
  * A manager to keep track of which entity type/bundles are OG group enabled.

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -307,22 +307,22 @@ class GroupManager {
     // Retrieve a cached version of the map if it exists.
     if ($group_relation_map = $this->state->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
       $this->groupRelationMap = $group_relation_map;
+      return;
     }
-    else {
-      $this->groupRelationMap = [];
 
-      foreach ($this->entityTypeBundleInfo->getAllBundleInfo() as $group_content_entity_type_id => $bundles) {
-        foreach ($bundles as $group_content_bundle_id => $bundle_info) {
-          foreach ($this->getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id) as $group_entity_type_id => $group_bundle_ids) {
-            foreach ($group_bundle_ids as $group_bundle_id) {
-              $this->groupRelationMap[$group_entity_type_id][$group_bundle_id][$group_content_entity_type_id][$group_content_bundle_id] = $group_content_bundle_id;
-            }
+    $this->groupRelationMap = [];
+
+    foreach ($this->entityTypeBundleInfo->getAllBundleInfo() as $group_content_entity_type_id => $bundles) {
+      foreach ($bundles as $group_content_bundle_id => $bundle_info) {
+        foreach ($this->getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id) as $group_entity_type_id => $group_bundle_ids) {
+          foreach ($group_bundle_ids as $group_bundle_id) {
+            $this->groupRelationMap[$group_entity_type_id][$group_bundle_id][$group_content_entity_type_id][$group_content_bundle_id] = $group_content_bundle_id;
           }
         }
       }
-      // Cache the map.
-      $this->state->set(self::GROUP_RELATION_MAP_CACHE_KEY, $this->groupRelationMap);
     }
+    // Cache the map.
+    $this->state->set(self::GROUP_RELATION_MAP_CACHE_KEY, $this->groupRelationMap);
   }
 
 }

--- a/src/GroupManager.php
+++ b/src/GroupManager.php
@@ -229,6 +229,17 @@ class GroupManager {
   }
 
   /**
+   * Refreshes the locally stored data.
+   *
+   * Call this after making a change to a relationship between a group type and
+   * a group content type.
+   */
+  public function refresh() {
+    $this->refreshGroupMap();
+    unset($this->groupRelationMap);
+  }
+
+  /**
    * Refreshes the groupMap property with currently configured groups.
    */
   protected function refreshGroupMap() {

--- a/src/Og.php
+++ b/src/Og.php
@@ -130,6 +130,8 @@ class Og {
     $view_display->setComponent($plugin_id, $view_display_definition);
     $view_display->save();
 
+    // Refresh the group manager data, we have added a group type.
+    static::groupManager()->refresh();
 
     return $field_definition;
   }

--- a/src/Og.php
+++ b/src/Og.php
@@ -131,7 +131,7 @@ class Og {
     $view_display->save();
 
     // Refresh the group manager data, we have added a group type.
-    static::groupManager()->refresh();
+    static::groupManager()->resetGroupRelationMap();
 
     return $field_definition;
   }

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -1,0 +1,557 @@
+<?php
+
+namespace Drupal\Tests\og\Kernel\Entity;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\node\Entity\NodeType;
+use Drupal\og\Og;
+use Drupal\og\OgGroupAudienceHelper;
+
+/**
+ * Tests retrieving group (content) bundles by group (content) bundles.
+ *
+ * @group og
+ * @coversDefaultClass \Drupal\og\GroupManager
+ */
+class GetBundleByBundleTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'block_content',
+    'field',
+    'node',
+    'og',
+    'system',
+    'user',
+  ];
+
+  /**
+   * Test groups.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface[][]
+   */
+  protected $groups = [];
+
+  /**
+   * Test group content.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $groupContent;
+
+  /**
+   * The group manager.
+   *
+   * @var \Drupal\og\GroupManager
+   */
+  protected $groupManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig(['og']);
+    $this->installEntitySchema('block_content');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('og_membership');
+    $this->installEntitySchema('user');
+    $this->installSchema('system', 'sequences');
+
+    $this->groupManager = $this->container->get('og.group.manager');
+
+    // Create four groups of two different entity types.
+    for ($i = 0; $i < 2; $i++) {
+      $bundle = "group_$i";
+      NodeType::create([
+        'name' => $this->randomString(),
+        'type' => $bundle,
+      ])->save();
+      Og::groupManager()->addGroup('node', $bundle);
+
+      BlockContentType::create(['id' => $bundle])->save();
+      Og::groupManager()->addGroup('block_content', $bundle);
+    }
+  }
+
+  /**
+   * Tests retrieval of bundles that are referenc[ed|ing] bundles.
+   *
+   * This tests the retrieval of the relations between groups and group content
+   * and vice versa. The retrieval of groups that are referenced by group
+   * content is done by GroupManager::getGroupBundleIdsByGroupContenBundle()
+   * while GroupManager::getGroupContentBundleIdsByGroupBundle() handles the
+   * opposite case.
+   *
+   * Both methods are tested here in a single test since they are very similar,
+   * and not having to set up the entire relationship structure twice reduces
+   * the total test running time.
+   *
+   * @param array $relationships
+   *   An array indicating the relationships between groups and group content
+   *   bundles that need to be set up in the test.
+   * @param array $expected_group_by_group_content
+   *   An array containing the expected results for the call to
+   *   getGroupBundleIdsByGroupContentBundle().
+   * @param array $expected_group_content_by_group
+   *   An array containing the expected results for the 4 calls to
+   *   getGroupContentBundleIdsByGroupBundle() that will be made in the test.
+   *
+   * @covers ::getGroupBundleIdsByGroupContentBundle
+   * @covers ::getGroupContentBundleIdsByGroupBundle
+   *
+   * @dataProvider getBundleIdsByBundleProvider
+   */
+  public function testGetBundleIdsByBundle(array $relationships, array $expected_group_by_group_content, array $expected_group_content_by_group) {
+    // Set up the relations as indicated in the test.
+    foreach ($relationships as $group_content_entity_type_id => $group_content_bundle_ids) {
+      foreach ($group_content_bundle_ids as $group_content_bundle_id => $group_audience_fields) {
+        switch ($group_content_entity_type_id) {
+          case 'node':
+            NodeType::create([
+              'name' => $this->randomString(),
+              'type' => $group_content_bundle_id,
+            ])->save();
+            break;
+          case 'block_content':
+            BlockContentType::create(['id' => $group_content_bundle_id])->save();
+            break;
+        }
+        foreach ($group_audience_fields as $group_audience_field_key => $group_audience_field_data) {
+          foreach ($group_audience_field_data as $group_entity_type_id => $group_bundle_ids) {
+            $settings = [
+              'field_name' => 'group_audience_' . $group_audience_field_key,
+              'field_storage_config' => [
+                'settings' => [
+                  'target_type' => $group_entity_type_id,
+                ],
+              ],
+            ];
+
+            if (!empty($group_bundle_ids)) {
+              $settings['field_config'] = [
+                'settings' => [
+                  'handler_settings' => [
+                    'target_bundles' => array_combine($group_bundle_ids, $group_bundle_ids),
+                  ],
+                ],
+              ];
+            }
+            Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, $group_content_entity_type_id, $group_content_bundle_id, $settings);
+          }
+        }
+      }
+    }
+
+    // Test ::getGroupBundleIdsByGroupContentBundle().
+    foreach ($expected_group_by_group_content as $group_content_entity_type_id => $group_content_bundle_ids) {
+      foreach ($group_content_bundle_ids as $group_content_bundle_id => $expected_result) {
+        $this->assertEquals($expected_result, $this->groupManager->getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id));
+      }
+    }
+
+    // Test ::getGroupContentBundleIdsByGroupBundle().
+    foreach (['node', 'block_content'] as $group_entity_type_id) {
+      for ($i = 0; $i < 2; $i++) {
+        $group_bundle_id = 'group_' . $i;
+
+        // If the expected value is omitted, we expect an empty array.
+        $expected_result = !empty($expected_group_content_by_group[$group_entity_type_id][$group_bundle_id]) ? $expected_group_content_by_group[$group_entity_type_id][$group_bundle_id] : [];
+
+        $this->assertEquals($expected_result, $this->groupManager->getGroupContentBundleIdsByGroupBundle($group_entity_type_id, $group_bundle_id));
+      }
+    }
+  }
+
+  /**
+   * Provides test data for testGetBundleIdsByBundle().
+   *
+   * @return array
+   *   An array of test properties. Each property is an indexed array with the
+   *   following items:
+   *   - An array indicating the relationships between groups and group content
+   *     bundles that need to be set up in the test.
+   *   - An array containing the expected results for the call to
+   *     getGroupBundleIdsByGroupContentBundle().
+   *   - An array containing the expected results for the 4 calls to
+   *     getGroupContentBundleIdsByGroupBundle() that will be made in the test.
+   *     If an empty array is expected to be returned, this result is omitted.
+   */
+  public function getBundleIdsByBundleProvider() {
+    return [
+      // Test the simplest case: a single group content type that references a
+      // single group type.
+      [
+        // The first parameter sets up the relations between groups and group
+        // content.
+        [
+          // Creating group content of type 'node'.
+          'node' => [
+            // The first of which...
+            'group_content_0' => [
+              // Has a single group audience field, configured to reference
+              // groups of type 'node', targeting bundle '0'.
+              ['node' => ['group_0']],
+            ],
+          ],
+        ],
+        // The second parameter contains the expected result for the call to
+        // getGroupBundleIdsByGroupContentBundle(). In this case we expect group
+        // '0' of type 'node' to be referenced.
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+            ],
+          ],
+        ],
+        // Finally, the third parameter contains all 4 expected results for the
+        // call to getGroupContentBundleIdsByGroupBundle(). In this test only
+        // node 0 should be referenced, all others should be empty.
+        // Note that if the result is expected to be an empty array it can be
+        // omitted from this list. In reality all 4 possible permutations will
+        // always be tested.
+        [
+          // When calling the method with entity type 'node' and bundle '0' we
+          // expect an array to be returned containing group content of type
+          // 'node', bundle '0'.
+          'node' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+            // There is no group content referencing group '1', so we expect an
+            // empty array. This may be omitted.
+            'group_1' => [],
+          ],
+          'block_content' => [
+            // This may be omitted.
+            'group_0' => [],
+            // This may be omitted.
+            'group_1' => [],
+          ],
+        ],
+      ],
+
+      // When the bundles are left empty, all bundles should be referenced.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => []],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+            'group_1' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+        ],
+      ],
+
+      // Test having two group audience fields referencing both group types.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => []],
+              ['block_content' => ['group_0', 'group_1']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+              'block_content' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+            'group_1' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+          'block_content' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+            'group_1' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+        ],
+      ],
+
+      // Test having two group audience fields, one referencing node group 0 and
+      // the other entity test group 1.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => ['group_0']],
+              ['block_content' => ['group_1']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+              'block_content' => ['group_1' => 'group_1'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+          'block_content' => [
+            'group_1' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+        ],
+      ],
+
+      // Test having two different group content entity types referencing the
+      // same group.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => ['group_0']],
+            ],
+          ],
+          'block_content' => [
+            'group_content_0' => [
+              ['node' => ['group_0']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+            ],
+          ],
+          'block_content' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => [
+              'node' => ['group_content_0' => 'group_content_0'],
+              'block_content' => ['group_content_0' => 'group_content_0'],
+            ],
+          ],
+        ],
+      ],
+
+      // Test having two identical group audience fields on the same group
+      // content type.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => ['group_0']],
+              ['node' => ['group_0']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+        ],
+      ],
+
+      // Test having two group audience fields on the same group content type,
+      // each referencing a different group bundle of the same type.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => ['group_0']],
+              ['node' => ['group_1']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => ['node' => ['group_content_0' => 'group_content_0']],
+            'group_1' => ['node' => ['group_content_0' => 'group_content_0']],
+          ],
+        ],
+      ],
+
+      // Test having two group content types referencing the same group. The
+      // second group content type also references another group with a second
+      // group audience field.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              ['node' => ['group_0']],
+            ],
+            'group_content_1' => [
+              ['node' => ['group_0']],
+              ['node' => ['group_1']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+            ],
+            'group_content_1' => [
+              'node' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => [
+              'node' => [
+                'group_content_0' => 'group_content_0',
+                'group_content_1' => 'group_content_1',
+              ],
+            ],
+            'group_1' => ['node' => ['group_content_1' => 'group_content_1']],
+          ],
+        ],
+      ],
+
+      // Bananas.
+      [
+        // Group to group content relationship matrix.
+        [
+          'node' => [
+            'group_content_0' => [
+              0 => ['node' => ['group_0']],
+              1 => ['block_content' => ['group_0', 'group_1']],
+            ],
+            'group_content_1' => [
+              2 => ['block_content' => ['group_1']],
+            ],
+          ],
+          'block_content' => [
+            'group_content_2' => [
+              0 => ['node' => ['group_0']],
+              1 => ['node' => ['group_0']],
+              2 => ['node' => ['group_1']],
+            ],
+            'group_content_3' => [
+              3 => ['block_content' => ['group_0', 'group_1']],
+            ],
+            'group_content_4' => [
+              4 => ['node' => ['group_0', 'group_1']],
+              5 => ['block_content' => ['group_1']],
+            ],
+          ],
+        ],
+        // Expected result for getGroupBundleIdsByGroupContentBundle().
+        [
+          'node' => [
+            'group_content_0' => [
+              'node' => ['group_0' => 'group_0'],
+              'block_content' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+            'group_content_1' => [
+              'block_content' => ['group_1' => 'group_1'],
+            ],
+          ],
+          'block_content' => [
+            'group_content_2' => [
+              'node' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+            'group_content_3' => [
+              'block_content' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+            ],
+            'group_content_4' => [
+              'node' => ['group_0' => 'group_0', 'group_1' => 'group_1'],
+              'block_content' => ['group_1' => 'group_1'],
+            ],
+          ],
+        ],
+        // Expected result for getGroupContentBundleIdsByGroupBundle().
+        [
+          'node' => [
+            'group_0' => [
+              'node' => ['group_content_0' => 'group_content_0'],
+              'block_content' => [
+                'group_content_2' => 'group_content_2',
+                'group_content_4' => 'group_content_4',
+              ],
+            ],
+            'group_1' => [
+              'block_content' => [
+                'group_content_2' => 'group_content_2',
+                'group_content_4' => 'group_content_4',
+              ],
+            ],
+          ],
+          'block_content' => [
+            'group_0' => [
+              'node' => ['group_content_0' => 'group_content_0'],
+              'block_content' => ['group_content_3' => 'group_content_3'],
+            ],
+            'group_1' => [
+              'node' => [
+                'group_content_0' => 'group_content_0',
+                'group_content_1' => 'group_content_1',
+              ],
+              'block_content' => [
+                'group_content_3' => 'group_content_3',
+                'group_content_4' => 'group_content_4',
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
+}

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -9,7 +9,7 @@ use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelper;
 
 /**
- * Tests retrieving group (content) bundles by group (content) bundles.
+ * Tests retrieving group content bundles by group bundles and vice versa.
  *
  * @group og
  * @coversDefaultClass \Drupal\og\GroupManager

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -54,22 +54,19 @@ class GroupManagerTest extends UnitTestCase {
    * @covers ::__construct
    */
   public function testInstance() {
-    $this->configProphecy->get('groups')
-      ->shouldBeCalled();
-
-    // Just creating an instance should not get the 'groups' config key.
-    $this->createGroupManager();
+    // Just creating an instance should be lightweight, no methods should be
+    // called.
+    $group_manager = $this->createGroupManager();
+    $this->assertInstanceOf(GroupManager::class, $group_manager);
   }
 
   /**
    * @covers ::getAllGroupBundles
    */
   public function testGetAllGroupBundles() {
+    // It is expected that the group map will be retrieved from config.
     $groups = ['test_entity' => ['a', 'b']];
-
-    $this->configProphecy->get('groups')
-      ->willReturn($groups)
-      ->shouldBeCalled();
+    $this->expectGroupMapRetrieval($groups);
 
     $manager = $this->createGroupManager();
 
@@ -82,11 +79,9 @@ class GroupManagerTest extends UnitTestCase {
    * @dataProvider providerTestIsGroup
    */
   public function testIsGroup($entity_type_id, $bundle_id, $expected) {
+    // It is expected that the group map will be retrieved from config.
     $groups = ['test_entity' => ['a', 'b']];
-
-    $this->configProphecy->get('groups')
-      ->willReturn($groups)
-      ->shouldBeCalled();
+    $this->expectGroupMapRetrieval($groups);
 
     $manager = $this->createGroupManager();
 
@@ -112,11 +107,9 @@ class GroupManagerTest extends UnitTestCase {
    * @covers ::getGroupsForEntityType
    */
   public function testGetGroupsForEntityType() {
+    // It is expected that the group map will be retrieved from config.
     $groups = ['test_entity' => ['a', 'b']];
-
-    $this->configProphecy->get('groups')
-      ->willReturn($groups)
-      ->shouldBeCalled();
+    $this->expectGroupMapRetrieval($groups);
 
     $manager = $this->createGroupManager();
 
@@ -132,11 +125,9 @@ class GroupManagerTest extends UnitTestCase {
       ->willReturn($this->configProphecy->reveal())
       ->shouldBeCalled();
 
+    // It is expected that the group map will be retrieved from config.
     $groups_before = ['test_entity' => ['a', 'b']];
-
-    $this->configProphecy->get('groups')
-      ->willReturn($groups_before)
-      ->shouldBeCalled();
+    $this->expectGroupMapRetrieval($groups_before);
 
     $groups_after = ['test_entity' => ['a', 'b', 'c']];
 
@@ -166,11 +157,9 @@ class GroupManagerTest extends UnitTestCase {
       ->willReturn($this->configProphecy->reveal())
       ->shouldBeCalled();
 
+    // It is expected that the group map will be retrieved from config.
     $groups_before = [];
-
-    $this->configProphecy->get('groups')
-      ->willReturn($groups_before)
-      ->shouldBeCalled();
+    $this->expectGroupMapRetrieval($groups_before);
 
     $groups_after = ['test_entity_new' => ['a']];
 
@@ -200,11 +189,9 @@ class GroupManagerTest extends UnitTestCase {
       ->willReturn($this->configProphecy->reveal())
       ->shouldBeCalled();
 
+    // It is expected that the group map will be retrieved from config.
     $groups_before = ['test_entity' => ['a', 'b']];
-
-    $this->configProphecy->get('groups')
-      ->willReturn($groups_before)
-      ->shouldBeCalled();
+    $this->expectGroupMapRetrieval($groups_before);
 
     $groups_after = ['test_entity' => ['a']];
 
@@ -233,15 +220,27 @@ class GroupManagerTest extends UnitTestCase {
    * @return \Drupal\og\GroupManager
    */
   protected function createGroupManager() {
-    $this->configFactoryProphecy->get('og.settings')
-      ->willReturn($this->configProphecy->reveal())
-      ->shouldBeCalled();
-
     return new GroupManager(
       $this->configFactoryProphecy->reveal(),
       $this->entityTypeBundleInfoProphecy->reveal(),
       $this->stateProphecy->reveal()
     );
+  }
+
+  /**
+   * Sets up an expectation that the group map will be retrieved from config.
+   *
+   * @param array $groups
+   *   The expected group map that will be returned by the mocked config.
+   */
+  protected function expectGroupMapRetrieval($groups = []) {
+    $this->configFactoryProphecy->get('og.settings')
+      ->willReturn($this->configProphecy->reveal())
+      ->shouldBeCalled();
+
+    $this->configProphecy->get('groups')
+      ->willReturn($groups)
+      ->shouldBeCalled();
   }
 
 }

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -27,11 +27,17 @@ class GroupManagerTest extends UnitTestCase {
   protected $configFactoryProphecy;
 
   /**
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $entityTypeBundleInfoProphecy;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
     $this->configProphecy = $this->prophesize('Drupal\Core\Config\Config');
     $this->configFactoryProphecy = $this->prophesize('Drupal\Core\Config\ConfigFactoryInterface');
+    $this->entityTypeBundleInfoProphecy = $this->prophesize('Drupal\Core\Entity\EntityTypeBundleInfoInterface');
   }
 
   /**
@@ -221,7 +227,7 @@ class GroupManagerTest extends UnitTestCase {
       ->willReturn($this->configProphecy->reveal())
       ->shouldBeCalled();
 
-    return new GroupManager($this->configFactoryProphecy->reveal());
+    return new GroupManager($this->configFactoryProphecy->reveal(), $this->entityTypeBundleInfoProphecy->reveal());
   }
 
 }

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -10,6 +10,7 @@ namespace Drupal\Tests\og\Unit;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\og\GroupManager;
 
@@ -35,12 +36,18 @@ class GroupManagerTest extends UnitTestCase {
   protected $entityTypeBundleInfoProphecy;
 
   /**
+   * @var \Drupal\Core\State\StateInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $stateProphecy;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
     $this->configProphecy = $this->prophesize(Config::class);
     $this->configFactoryProphecy = $this->prophesize(ConfigFactoryInterface::class);
     $this->entityTypeBundleInfoProphecy = $this->prophesize(EntityTypeBundleInfoInterface::class);
+    $this->stateProphecy = $this->prophesize(StateInterface::class);
   }
 
   /**
@@ -230,7 +237,11 @@ class GroupManagerTest extends UnitTestCase {
       ->willReturn($this->configProphecy->reveal())
       ->shouldBeCalled();
 
-    return new GroupManager($this->configFactoryProphecy->reveal(), $this->entityTypeBundleInfoProphecy->reveal());
+    return new GroupManager(
+      $this->configFactoryProphecy->reveal(),
+      $this->entityTypeBundleInfoProphecy->reveal(),
+      $this->stateProphecy->reveal()
+    );
   }
 
 }

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -7,8 +7,11 @@
 
 namespace Drupal\Tests\og\Unit;
 
-use Drupal\og\GroupManager;
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Tests\UnitTestCase;
+use Drupal\og\GroupManager;
 
 /**
  * @group og
@@ -35,9 +38,9 @@ class GroupManagerTest extends UnitTestCase {
    * {@inheritdoc}
    */
   public function setUp() {
-    $this->configProphecy = $this->prophesize('Drupal\Core\Config\Config');
-    $this->configFactoryProphecy = $this->prophesize('Drupal\Core\Config\ConfigFactoryInterface');
-    $this->entityTypeBundleInfoProphecy = $this->prophesize('Drupal\Core\Entity\EntityTypeBundleInfoInterface');
+    $this->configProphecy = $this->prophesize(Config::class);
+    $this->configFactoryProphecy = $this->prophesize(ConfigFactoryInterface::class);
+    $this->entityTypeBundleInfoProphecy = $this->prophesize(EntityTypeBundleInfoInterface::class);
   }
 
   /**


### PR DESCRIPTION
This has been split off from PR #192.

In order to build a permission matrix for a given group type we need to be able to get the inverse relationship from group types to group content types.

In this PR I propose two methods in `GroupManager`:
- `getGroupContentBundleIdsByGroupBundle($group_entity_type_id, $group_bundle_id)` returns an array containing all group content bundles that reference the given group type.
- `getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id)` does the inverse: it will return an array containing all group bundles that are referenced by the group content type.
