### PR TITLE
Replace Drupal 8.0.x with 8.2.x in Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ php:
   - 7.0
 
 env:
-  - DRUPAL_CORE=8.0.x
   - DRUPAL_CORE=8.1.x
+  - DRUPAL_CORE=8.2.x
 
 mysql:
   database: og
@@ -38,8 +38,8 @@ before_script:
   - travis_retry git clone --branch $DRUPAL_CORE --depth 1 https://git.drupal.org/project/drupal.git
   - cd drupal
 
-  # Install Composer dependencies on 8.1.x.
-  - test ${DRUPAL_CORE} == "8.1.x" && composer self-update && composer install || true
+  # Install Composer dependencies.
+  - composer self-update && composer install
 
   # Reference OG in the Drupal site.
   - ln -s $TESTDIR modules/og


### PR DESCRIPTION
Drupal 8.0.x is now obsolete, and 8.2.x is in development. Let's update our test matrix accordingly.
