### PR TITLE
Fix permissions for non-administrators

### DIFF
--- a/og.module
+++ b/og.module
@@ -104,8 +104,15 @@ function og_entity_field_access($operation, FieldDefinitionInterface $field_defi
  * Implements hook_entity_access().
  */
 function og_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
-  // We only care about content entities.
+  // We only care about content entities that are groups or group content.
   if (!$entity instanceof ContentEntityInterface) {
+    return AccessResult::neutral();
+  }
+
+  $entity_type_id = $entity->getEntityTypeId();
+  $bundle_id = $entity->bundle();
+
+  if (!Og::isGroup($entity_type_id, $bundle_id) && !Og::isGroupContent($entity_type_id, $bundle_id)) {
     return AccessResult::neutral();
   }
 
@@ -120,7 +127,6 @@ function og_entity_access(EntityInterface $entity, $operation, AccountInterface 
     return $access;
   }
 
-  $entity_type_id = $entity->getEntityTypeId();
   if ($entity_type_id == 'node') {
     $node_access_strict = \Drupal::config('og.settings')->get('node_access_strict');
 

--- a/og.module
+++ b/og.module
@@ -109,6 +109,10 @@ function og_entity_access(EntityInterface $entity, $operation, AccountInterface 
     return AccessResult::neutral();
   }
 
+  if ($operation == 'view') {
+    return AccessResult::neutral();
+  }
+
   $entity_type_id = $entity->getEntityTypeId();
   $bundle_id = $entity->bundle();
 

--- a/og.module
+++ b/og.module
@@ -113,28 +113,18 @@ function og_entity_access(EntityInterface $entity, $operation, AccountInterface 
     return AccessResult::neutral();
   }
 
-  $entity_type_id = $entity->getEntityTypeId();
-  $bundle_id = $entity->bundle();
-
-  $access = OgAccess::userAccessEntity('administer group', $entity, $account);
-
-  if ($access->isNeutral()) {
-    // The node isn't in an OG context, so no need to keep testing.
-    return $access;
-  }
-  else {
-    // Any and own content.
-    $access = $access->orIf(OgAccess::userAccessEntity($operation, $entity, $account));
+  // If the user has permission to administer all groups, allow access.
+  if ($account->hasPermission('administer group')) {
+    return AccessResult::neutral();
   }
 
-  if (!$access->isAllowed() && ($operation === 'update') && Og::isGroup($entity_type_id, $bundle_id)) {
-    $access = OgAccess::userAccessEntity($operation, $entity, $account);
-  }
+  $access = OgAccess::userAccessEntity($operation, $entity, $account);
 
   if ($access->isAllowed()) {
     return $access;
   }
 
+  $entity_type_id = $entity->getEntityTypeId();
   if ($entity_type_id == 'node') {
     $node_access_strict = \Drupal::config('og.settings')->get('node_access_strict');
 

--- a/og.module
+++ b/og.module
@@ -109,13 +109,9 @@ function og_entity_access(EntityInterface $entity, $operation, AccountInterface 
     return AccessResult::neutral();
   }
 
-  if ($operation == 'view') {
-    return AccessResult::neutral();
-  }
-
   // If the user has permission to administer all groups, allow access.
   if ($account->hasPermission('administer group')) {
-    return AccessResult::neutral();
+    return AccessResult::allowed();
   }
 
   $access = OgAccess::userAccessEntity($operation, $entity, $account);

--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -36,6 +36,11 @@ class OgAccessHookTest extends OgAccessEntityTestBase {
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
     $user_entity_access = og_entity_access($this->entity->reveal(), $operation, $this->user->reveal());
-    $this->assertTrue($user_entity_access->isAllowed());
+    if ($operation == 'view') {
+      $this->assertTrue($user_entity_access->isNeutral());
+    }
+    else {
+      $this->assertTrue($user_entity_access->isAllowed());
+    }
   }
 }

--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -36,11 +36,6 @@ class OgAccessHookTest extends OgAccessEntityTestBase {
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
     $user_entity_access = og_entity_access($this->entity->reveal(), $operation, $this->user->reveal());
-    if ($operation == 'view') {
-      $this->assertTrue($user_entity_access->isNeutral());
-    }
-    else {
-      $this->assertTrue($user_entity_access->isAllowed());
-    }
+    $this->assertTrue($user_entity_access->isAllowed());
   }
 }


### PR DESCRIPTION
The logic in `og_entity_access()` is faulty. It is calling `OgAccess::userAccessEntity()` with the operation 'administer group', but this is invalid, the only allowed entity operations are 'view', 'create', 'update' and 'delete'.

It also seems that some of the other code in `og_entity_access()` are earlier attempts for working around this bug.

The solution seems pretty simple, if the user has the 'administer group' permission, then we simply return `AccessResult::neutral()`, which will grant access according to the user's normal privileges.

Let's see what this breaks.
