### PR TITLE
Add temporary workaround for core bug #2744089.

### DIFF
--- a/og_ui/tests/src/Functional/BundleFormAlterTest.php
+++ b/og_ui/tests/src/Functional/BundleFormAlterTest.php
@@ -164,4 +164,15 @@ class BundleFormAlterTest extends BrowserTestBase {
     $this->assertEquals($expected, $setting, $message);
   }
 
+  /**
+   * Temporary workaround for a core bug that has the visibility wrong for this.
+   *
+   * Remove this once issue #2744089 is fixed.
+   *
+   * @see https://www.drupal.org/node/2744089
+   */
+  public function assertLink($label, $index = 0) {
+    return $this->assertSession()->linkExists($label, $index);
+  }
+
 }


### PR DESCRIPTION
Our tests are currently failing because of a visibility change that was introduced to the `assertLink()` method in [Issue #2735045: Convert StandardTest to BrowserTestBase by introducing a AssertLegacyTrait and new assertions on the WebAssert](https://www.drupal.org/node/2735045).

Here is an example of a failing test because of this: https://travis-ci.org/amitaibu/og/jobs/135845144. The following error is thrown:

> Fatal error:  Access level to Drupal\simpletest\AssertContentTrait::assertLink() must be public (as in class Drupal\Tests\BrowserTestBase) in /home/travis/build/amitaibu/og/og_ui/tests/src/Functional/BundleFormAlterTest.php on line 24

A fix is proposed in [Issue #2744089: Fix visibility of AssertLegacyTrait::assertLink()](https://www.drupal.org/node/2744089) and it is already RTBC, but here is a workaround that will unblock our tests awaiting the core issue to be committed.
