### PR TITLE
Utilize Role isAdmin() functionality

### DIFF
--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -110,6 +110,9 @@ og.og_role.*:
     group_bundle:
       type: string
       label: 'Group bundle'
+    is_admin:
+      type: boolean
+      label: 'User is group admin'
     permissions:
       type: sequence
       label: 'Permissions'

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -25,6 +25,7 @@ use Drupal\user\Entity\Role;
  *     "id",
  *     "label",
  *     "weight",
+ *     "is_admin",
  *     "group_type",
  *     "group_bundle",
  *     "group_id",

--- a/src/Og.php
+++ b/src/Og.php
@@ -256,6 +256,30 @@ class Og {
   }
 
   /**
+   * Returns the group membership for a given user and group.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user to get the membership for.
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group to get the membership for.
+   * @param array $states
+   *   (optional) Array with the state to return. Defaults to active.
+   * @param string $field_name
+   *   (optional) The field name associated with the group.
+   *
+   * @return \Drupal\og\Entity\OgMembership|NULL
+   *   The OgMembership entity, or NULL if the user is not a member of the
+   *   group.
+   */
+  public static function getUserMembership(AccountInterface $user, EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE], $field_name = NULL) {
+    foreach (static::getUserMemberships($user, $states, $field_name) as $membership) {
+      if ($membership->getGroupEntityType() === $group->getEntityTypeId() && $membership->getEntityId() === $group->id()) {
+        return $membership;
+      }
+    }
+  }
+
+  /**
    * Returns all group IDs associated with the given group content entity.
    *
    * Do not use this to retrieve group IDs associated with a user entity. Use

--- a/src/Og.php
+++ b/src/Og.php
@@ -271,7 +271,7 @@ class Og {
    *   The OgMembership entity, or NULL if the user is not a member of the
    *   group.
    */
-  public static function getUserMembership(AccountInterface $user, EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE], $field_name = NULL) {
+  public static function getMembership(AccountInterface $user, EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE], $field_name = NULL) {
     foreach (static::getUserMemberships($user, $states, $field_name) as $membership) {
       if ($membership->getGroupEntityType() === $group->getEntityTypeId() && $membership->getEntityId() === $group->id()) {
         return $membership;

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -279,7 +279,11 @@ class OgAccess {
 
     return isset(static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type]) ?
       static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type] :
-      [];
+      [
+        'permissions' => [],
+        'is_admin' => FALSE,
+        'cacheable_metadata' => NULL,
+      ];
   }
 
   /**

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -114,9 +114,8 @@ class OgAccess {
       $permissions = [];
       $user_is_group_admin = FALSE;
 
-      foreach (Og::getUserMemberships($user) as $membership) {
+      if ($membership = Og::getUserMembership($user, $group)) {
         foreach ($membership->getRoles() as $role) {
-
           /** @var $role RoleInterface */
           $permissions = array_merge($permissions, $role->getPermissions());
 

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -279,11 +279,7 @@ class OgAccess {
 
     return isset(static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type]) ?
       static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type] :
-      [
-        'permissions' => [],
-        'is_admin' => FALSE,
-        'cacheable_metadata' => NULL,
-      ];
+      [];
   }
 
   /**

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -114,15 +114,16 @@ class OgAccess {
       $permissions = [];
       $user_is_group_admin = FALSE;
 
-      if ($membership = Og::getUserMembership($user, $group)) {
+      if ($membership = Og::getMembership($user, $group)) {
         foreach ($membership->getRoles() as $role) {
-          /** @var $role RoleInterface */
-          $permissions = array_merge($permissions, $role->getPermissions());
-
-          // Set an is_admin flag.
+          // Check for the is_admin flag.
           if ($role->isAdmin()) {
             $user_is_group_admin = TRUE;
+            break;
           }
+
+          /** @var $role RoleInterface */
+          $permissions = array_merge($permissions, $role->getPermissions());
         }
       }
 

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -123,7 +123,6 @@ class OgAccessTestBase extends UnitTestCase {
     $reflection_property = $r->getProperty('permissionsCache');
     $reflection_property->setAccessible(TRUE);
 
-
     $values = [];
     foreach (['pre_alter', 'post_alter'] as $key) {
       $values[$group_type_id][$this->group->id()][2][$key] = ['permissions' => ['update group'], 'is_admin' => FALSE];

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -126,7 +126,7 @@ class OgAccessTestBase extends UnitTestCase {
 
     $values = [];
     foreach (['pre_alter', 'post_alter'] as $key) {
-      $values[$group_type_id][$this->group->id()][2][$key] = ['permissions' => ['update group']];
+      $values[$group_type_id][$this->group->id()][2][$key] = ['permissions' => ['update group'], 'is_admin' => FALSE];
     }
 
     $reflection_property->setValue($values);


### PR DESCRIPTION
Currently we extend `Role` with `OgRole` but remove the `is_admin` flag usage, but all the methods are available. We are also using all the Role methods to check a role has a permission etc.. isAdmin() is built into all that. As if a role have that, it will always return true. So this is a simpler way of implementing admin permission checking, and being more in line with core.
