### PR TITLE
Convert OgAccess into a service

### DIFF
--- a/og.module
+++ b/og.module
@@ -125,7 +125,8 @@ function og_entity_access(EntityInterface $entity, $operation, AccountInterface 
     return AccessResult::allowed();
   }
 
-  $access = OgAccess::userAccessEntity($operation, $entity, $account);
+  /** @var \Drupal\Core\Access\AccessResult $access */
+  $access = \Drupal::service('og.access')->userAccessEntity($operation, $entity, $account);
 
   if ($access->isAllowed()) {
     return $access;

--- a/og.services.yml
+++ b/og.services.yml
@@ -1,4 +1,7 @@
 services:
+  og.access:
+    class: Drupal\og\OgAccess
+    arguments: ['@config.factory', '@current_user', '@module_handler']
   og.event_subscriber:
     class: Drupal\og\EventSubscriber\OgEventSubscriber
     arguments: ['@og.permission_manager']

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -312,7 +312,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
 
     // Reset internal cache.
     Og::reset();
-    OgAccess::reset();
+    \Drupal::service('og.access')->reset();
 
     return $result;
   }

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -10,23 +10,18 @@ namespace Drupal\og;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
-use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\user\EntityOwnerInterface;
 use Drupal\user\RoleInterface;
 
-class OgAccess {
-
-  /**
-   * Static cache that contains cache permissions.
-   *
-   * @var array
-   *   Array keyed by the following keys:
-   *   - alter: The permissions after altered by implementing modules.
-   *   - pre_alter: The pre-altered permissions, as read from the config.
-   */
-  protected static $permissionsCache = [];
-
+/**
+ * The service that determines if users have access to groups and group content.
+ */
+class OgAccess implements OgAccessInterface {
 
   /**
    * Administer permission string.
@@ -36,38 +31,61 @@ class OgAccess {
   const ADMINISTER_GROUP_PERMISSION = 'administer group';
 
   /**
-   * Determines whether a user has a given privilege.
+   * Static cache that contains cache permissions.
    *
-   * All permission checks in OG should go through this function. This
-   * way, we guarantee consistent behavior, and ensure that the superuser
-   * and group administrators can perform all actions.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $group
-   *   The group entity.
-   * @param string $operation
-   *   The entity operation being checked for.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   (optional) The user to check. Defaults to the current user.
-   * @param $skip_alter
-   *   (optional) If TRUE then user access will not be sent to other modules
-   *   using drupal_alter(). This can be used by modules implementing
-   *   hook_og_user_access_alter() that still want to use og_user_access(), but
-   *   without causing a recursion. Defaults to FALSE.
-   * @param $ignore_admin
-   *   (optional) When TRUE the specific permission is checked, ignoring the
-   *   "administer group" permission if the user has it. When FALSE, a user
-   *   with "administer group" will be granted all permissions.
-   *   Defaults to FALSE.
-   *
-   * @return \Drupal\Core\Access\AccessResult
-   *   An access result object.
+   * @var array
+   *   Array keyed by the following keys:
+   *   - alter: The permissions after altered by implementing modules.
+   *   - pre_alter: The pre-altered permissions, as read from the config.
    */
-  public static function userAccess(EntityInterface $group, $operation, AccountInterface $user = NULL, $skip_alter = FALSE, $ignore_admin = FALSE) {
+  protected $permissionsCache = [];
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The service that contains the current active user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $accountProxy;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs an OgManager service.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Session\AccountProxyInterface $account_proxy
+   *   The service that contains the current active user.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, AccountProxyInterface $account_proxy, ModuleHandlerInterface $module_handler) {
+    $this->configFactory = $config_factory;
+    $this->accountProxy = $account_proxy;
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userAccess(EntityInterface $group, $operation, AccountInterface $user = NULL, $skip_alter = FALSE, $ignore_admin = FALSE) {
     $group_type_id = $group->getEntityTypeId();
     $bundle = $group->bundle();
     // As Og::isGroup depends on this config, we retrieve it here and set it as
     // the minimal caching data.
-    $config = \Drupal::config('og.settings');
+    $config = $this->configFactory->get('og.settings');
     $cacheable_metadata = (new CacheableMetadata)
         ->addCacheableDependency($config);
     if (!Og::isGroup($group_type_id, $bundle)) {
@@ -76,12 +94,12 @@ class OgAccess {
     }
 
     if (!isset($user)) {
-      $user = \Drupal::currentUser()->getAccount();
+      $user = $this->accountProxy->getAccount();
     }
 
     // From this point on, every result also depends on the user so check
     // whether it is the current. See https://www.drupal.org/node/2628870
-    if ($user->id() == \Drupal::currentUser()->id()) {
+    if ($user->id() == $this->accountProxy->id()) {
       $cacheable_metadata->addCacheContexts(['user']);
     }
 
@@ -92,7 +110,7 @@ class OgAccess {
 
     // Administer group permission.
     if (!$ignore_admin) {
-      $user_access = AccessResult::allowedIfHasPermission($user, static::ADMINISTER_GROUP_PERMISSION);
+      $user_access = AccessResult::allowedIfHasPermission($user, self::ADMINISTER_GROUP_PERMISSION);
       if ($user_access->isAllowed()) {
         return $user_access->addCacheableDependency($cacheable_metadata);
       }
@@ -106,11 +124,10 @@ class OgAccess {
       }
     }
 
-    $pre_alter_cache = static::getPermissionsCache($group, $user, TRUE);
-    $post_alter_cache = static::getPermissionsCache($group, $user, FALSE);
+    $pre_alter_cache = $this->getPermissionsCache($group, $user, TRUE);
+    $post_alter_cache = $this->getPermissionsCache($group, $user, FALSE);
 
-    // To reduce the number of SQL queries, we cache the user's permissions
-    // in a static variable.
+    // To reduce the number of SQL queries, we cache the user's permissions.
     if (!$pre_alter_cache) {
       $permissions = array();
 
@@ -123,27 +140,27 @@ class OgAccess {
         }
       }
 
-      static::setPermissionCache($group, $user, TRUE, $permissions, $cacheable_metadata);
+      $this->setPermissionCache($group, $user, TRUE, $permissions, $cacheable_metadata);
     }
 
     if (!$skip_alter && !in_array($operation, $post_alter_cache)) {
       // Let modules alter the permissions. So we get the original ones, and
       // pass them along to the implementing modules.
-      $alterable_permissions = static::getPermissionsCache($group, $user, TRUE);
+      $alterable_permissions = $this->getPermissionsCache($group, $user, TRUE);
 
       $context = array(
         'operation' => $operation,
         'group' => $group,
         'user' => $user,
       );
-      \Drupal::moduleHandler()->alter('og_user_access', $alterable_permissions['permissions'], $cacheable_metadata, $context);
+      $this->moduleHandler->alter('og_user_access', $alterable_permissions['permissions'], $cacheable_metadata, $context);
 
-      static::setPermissionCache($group, $user, FALSE, $alterable_permissions['permissions'], $cacheable_metadata);
+      $this->setPermissionCache($group, $user, FALSE, $alterable_permissions['permissions'], $cacheable_metadata);
     }
 
-    $altered_permissions = static::getPermissionsCache($group, $user, FALSE);
+    $altered_permissions = $this->getPermissionsCache($group, $user, FALSE);
 
-    $user_is_group_admin = !empty($altered_permissions['permissions'][static::ADMINISTER_GROUP_PERMISSION]);
+    $user_is_group_admin = !empty($altered_permissions['permissions'][self::ADMINISTER_GROUP_PERMISSION]);
     if (($user_is_group_admin && !$ignore_admin) || in_array($operation, $altered_permissions['permissions'])) {
       // User is a group admin, and we do not ignore this special permission
       // that grants access to all the group permissions.
@@ -154,18 +171,9 @@ class OgAccess {
   }
 
   /**
-   * Check if a user has access to a permission on a certain entity context.
-   *
-   * @param string $operation
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity object.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   (optional) The user object. If empty the current user will be used.
-   *
-   * @return \Drupal\Core\Access\AccessResult
-   *   An access result object.
+   * {@inheritdoc}
    */
-  public static function userAccessEntity($operation, EntityInterface $entity, AccountInterface $user = NULL) {
+  public function userAccessEntity($operation, EntityInterface $entity, AccountInterface $user = NULL) {
     $result = AccessResult::neutral();
 
     // Entity isn't saved yet.
@@ -178,7 +186,7 @@ class OgAccess {
     $bundle = $entity->bundle();
 
     if (Og::isGroup($entity_type_id, $bundle)) {
-      $user_access = static::userAccess($entity, $operation, $user);
+      $user_access = $this->userAccess($entity, $operation, $user);
       if ($user_access->isAllowed()) {
         return $user_access;
       }
@@ -203,7 +211,7 @@ class OgAccess {
       $forbidden = AccessResult::forbidden()->addCacheTags($cache_tags);
       foreach ($groups as $entity_groups) {
         foreach ($entity_groups as $group) {
-          $user_access = static::userAccess($group, $operation, $user);
+          $user_access = $this->userAccess($group, $operation, $user);
           if ($user_access->isAllowed()) {
             return $user_access->addCacheTags($cache_tags);
           }
@@ -236,13 +244,13 @@ class OgAccess {
    * @param \Drupal\Core\Cache\RefinableCacheableDependencyInterface $cacheable_metadata
    *   A cacheable metadata object.
    */
-  protected static function setPermissionCache(EntityInterface $group, AccountInterface $user, $pre_alter, array $permissions, RefinableCacheableDependencyInterface $cacheable_metadata) {
+  protected function setPermissionCache(EntityInterface $group, AccountInterface $user, $pre_alter, array $permissions, RefinableCacheableDependencyInterface $cacheable_metadata) {
     $entity_type_id = $group->getEntityTypeId();
     $group_id = $group->id();
     $user_id = $user->id();
     $type = $pre_alter ? 'pre_alter' : 'post_alter';
 
-    static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type] = [
+    $this->permissionsCache[$entity_type_id][$group_id][$user_id][$type] = [
       'permissions' => $permissions,
       'cacheable_metadata' => $cacheable_metadata,
     ];
@@ -261,22 +269,22 @@ class OgAccess {
    * @return array
    *   Array of permissions if cached, or an empty array.
    */
-  protected static function getPermissionsCache(EntityInterface $group, AccountInterface $user, $pre_alter) {
+  protected function getPermissionsCache(EntityInterface $group, AccountInterface $user, $pre_alter) {
     $entity_type_id = $group->getEntityTypeId();
     $group_id = $group->id();
     $user_id = $user->id();
     $type = $pre_alter ? 'pre_alter' : 'post_alter';
 
-    return isset(static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type]) ?
-      static::$permissionsCache[$entity_type_id][$group_id][$user_id][$type] :
+    return isset($this->permissionsCache[$entity_type_id][$group_id][$user_id][$type]) ?
+      $this->permissionsCache[$entity_type_id][$group_id][$user_id][$type] :
       [];
   }
 
   /**
-   * Resets the static cache.
+   * {@inheritdoc}
    */
-  public static function reset() {
-    static::$permissionsCache = [];
+  public function reset() {
+    $this->permissionsCache = [];
   }
 
 }

--- a/src/OgAccessInterface.php
+++ b/src/OgAccessInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\og;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Interface for classes that handle access checks in Organic Groups.
+ */
+interface OgAccessInterface {
+
+  /**
+   * Determines whether a user has a given privilege.
+   *
+   * All permission checks in OG should go through this function. This way we
+   * guarantee consistent behavior, and ensure that the superuser and group
+   * administrators can perform all actions.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group entity.
+   * @param string $operation
+   *   The entity operation being checked for.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   (optional) The user to check. Defaults to the current user.
+   * @param $skip_alter
+   *   (optional) If TRUE then user access will not be sent to other modules
+   *   using drupal_alter(). This can be used by modules implementing
+   *   hook_og_user_access_alter() that still want to use og_user_access(), but
+   *   without causing a recursion. Defaults to FALSE.
+   * @param $ignore_admin
+   *   (optional) When TRUE the specific permission is checked, ignoring the
+   *   "administer group" permission if the user has it. When FALSE, a user
+   *   with "administer group" will be granted all permissions.
+   *   Defaults to FALSE.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   An access result object.
+   */
+  public function userAccess(EntityInterface $group, $operation, AccountInterface $user = NULL, $skip_alter = FALSE, $ignore_admin = FALSE);
+
+  /**
+   * Check if a user has access to a permission on a certain entity context.
+   *
+   * @param string $operation
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity object.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   (optional) The user object. If empty the current user will be used.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   An access result object.
+   */
+  public function userAccessEntity($operation, EntityInterface $entity, AccountInterface $user = NULL);
+
+  /**
+   * Resets the static cache.
+   */
+  public function reset();
+
+}

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -157,14 +157,16 @@ class OgEntityAccessTest extends KernelTestBase {
    * Test access to an arbitrary permission.
    */
   public function testAccess() {
+    $og_access = $this->container->get('og.access');
+
     // A member user.
-    $this->assertTrue(OgAccess::userAccess($this->group1, 'some_perm', $this->user1)->isAllowed());
+    $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user1)->isAllowed());
 
     // A member user without the correct role.
-    $this->assertTrue(OgAccess::userAccess($this->group1, 'some_perm', $this->user2)->isForbidden());
+    $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user2)->isForbidden());
 
     // A non-member user.
-    $this->assertTrue(OgAccess::userAccess($this->group1, 'some_perm', $this->user3)->isForbidden());
+    $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user3)->isForbidden());
 
     // Add membership to user 3.
     $membership = OgMembership::create(['type' => OgMembershipInterface::TYPE_DEFAULT]);
@@ -175,7 +177,7 @@ class OgEntityAccessTest extends KernelTestBase {
       ->addRole($this->ogRoleWithPermission->id())
       ->save();
 
-    $this->assertTrue(OgAccess::userAccess($this->group1, 'some_perm', $this->user3)->isAllowed());
+    $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user3)->isAllowed());
   }
 
 

--- a/tests/src/Unit/OgAccessEntityTest.php
+++ b/tests/src/Unit/OgAccessEntityTest.php
@@ -23,7 +23,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
   public function testAccessByOperation($operation) {
     $group_entity = $this->groupEntity();
     $group_entity->isNew()->willReturn(FALSE);
-    $user_access = OgAccess::userAccessEntity($operation, $this->entity->reveal(), $this->user->reveal());
+    $user_access = $this->ogAccess->userAccessEntity($operation, $this->entity->reveal(), $this->user->reveal());
 
     // We populate the allowed permissions cache in
     // OgAccessEntityTestBase::setup().
@@ -38,7 +38,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
   public function testEntityNew($operation) {
     $group_entity = $this->groupEntity();
     $group_entity->isNew()->willReturn(TRUE);
-    $user_access = OgAccess::userAccessEntity($operation, $group_entity->reveal(), $this->user->reveal());
+    $user_access = $this->ogAccess->userAccessEntity($operation, $group_entity->reveal(), $this->user->reveal());
     $this->assertTrue($user_access->isNeutral());
   }
 
@@ -48,7 +48,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
    */
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
-    $user_entity_access = OgAccess::userAccessEntity($operation, $this->entity->reveal(), $this->user->reveal());
+    $user_entity_access = $this->ogAccess->userAccessEntity($operation, $this->entity->reveal(), $this->user->reveal());
     $this->assertTrue($user_entity_access->isAllowed());
   }
 

--- a/tests/src/Unit/OgAccessEntityTestBase.php
+++ b/tests/src/Unit/OgAccessEntityTestBase.php
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\og\OgAccessInterface;
 use Drupal\og\OgGroupAudienceHelper;
 use Prophecy\Argument;
 

--- a/tests/src/Unit/OgAccessTest.php
+++ b/tests/src/Unit/OgAccessTest.php
@@ -21,7 +21,7 @@ class OgAccessTest extends OgAccessTestBase {
    */
   public function testUserAccessNotAGroup($operation) {
     $this->groupManager->isGroup($this->entityTypeId, $this->bundle)->willReturn(FALSE);
-    $user_access = OgAccess::userAccess($this->group, $operation);
+    $user_access = $this->ogAccess->userAccess($this->group, $operation);
     $this->assertTrue($user_access->isNeutral());
   }
 
@@ -30,7 +30,7 @@ class OgAccessTest extends OgAccessTestBase {
    * @dataProvider operationProvider
    */
   public function testAccessByOperation($operation) {
-    $user_access = OgAccess::userAccess($this->group, $operation, $this->user->reveal());
+    $user_access = $this->ogAccess->userAccess($this->group, $operation, $this->user->reveal());
 
     // We populate the allowed permissions cache in
     // OgAccessTestBase::setup().
@@ -45,7 +45,7 @@ class OgAccessTest extends OgAccessTestBase {
    */
   public function testUserAccessUser1($operation) {
     $this->user->id()->willReturn(1);
-    $user_access = OgAccess::userAccess($this->group, $operation, $this->user->reveal());
+    $user_access = $this->ogAccess->userAccess($this->group, $operation, $this->user->reveal());
     $this->assertTrue($user_access->isAllowed());
   }
 
@@ -55,7 +55,7 @@ class OgAccessTest extends OgAccessTestBase {
    */
   public function testUserAccessAdminPermission($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
-    $user_access = OgAccess::userAccess($this->group, $operation, $this->user->reveal());
+    $user_access = $this->ogAccess->userAccess($this->group, $operation, $this->user->reveal());
     $this->assertTrue($user_access->isAllowed());
   }
 
@@ -65,7 +65,7 @@ class OgAccessTest extends OgAccessTestBase {
    */
   public function testUserAccessOwner($operation) {
     $this->config->get('group_manager_full_access')->willReturn(TRUE);
-    $user_access = OgAccess::userAccess($this->groupEntity(TRUE)->reveal(), $operation, $this->user->reveal());
+    $user_access = $this->ogAccess->userAccess($this->groupEntity(TRUE)->reveal(), $operation, $this->user->reveal());
     $this->assertTrue($user_access->isAllowed());
   }
 

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -7,18 +7,19 @@
 
 namespace Drupal\Tests\og\Unit;
 
-use Drupal\user\EntityOwnerInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\Config;
-use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\og\OgAccess;
-use Drupal\og\OgMembershipInterface;
-use Drupal\Tests\UnitTestCase;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Tests\UnitTestCase;
 use Drupal\og\GroupManager;
+use Drupal\og\OgAccess;
+use Drupal\og\OgMembershipInterface;
+use Drupal\user\EntityOwnerInterface;
 use Prophecy\Argument;
 
 class OgAccessTestBase extends UnitTestCase {
@@ -47,6 +48,16 @@ class OgAccessTestBase extends UnitTestCase {
    */
   protected $groupManager;
 
+  /**
+   * The OgAccess class, this is the system under test.
+   *
+   * @var \Drupal\og\OgAccessInterface
+   */
+  protected $ogAccess;
+
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     $this->entityTypeId = $this->randomMachineName();
     $this->bundle = $this->randomMachineName();
@@ -57,10 +68,19 @@ class OgAccessTestBase extends UnitTestCase {
     $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);
     $cache_contexts_manager->assertValidTokens(Argument::any())->willReturn(TRUE);
 
+    // It is expected that any access check will retrieve the settings, because
+    // it contains an option to give full access to to the group manager.
     $this->config = $this->addCache($this->prophesize(Config::class));
     $this->config->get('group_manager_full_access')->willReturn(FALSE);
 
-    $config_factory = $this->prophesize(ConfigFactory::class);
+    // Since access depends on the 'group_manager_full_access' setting this
+    // means that access varies by the config object that contains this setting.
+    // It is expected that the cacheability metadata is retrieved from it.
+    $this->config->getCacheContexts()->willReturn([]);
+    $this->config->getCacheTags()->willReturn([]);
+    $this->config->getCacheMaxAge()->willReturn(0);
+
+    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
     $config_factory->get('og.settings')->willReturn($this->config);
 
     $this->user = $this->prophesize(AccountInterface::class);
@@ -81,6 +101,12 @@ class OgAccessTestBase extends UnitTestCase {
     $group_type_id = $this->group->getEntityTypeId();
 
     $entity_id = 20;
+
+    $account_proxy = $this->prophesize(AccountProxyInterface::class);
+    $module_handler = $this->prophesize(ModuleHandlerInterface::class);
+
+    // Instantiate the system under test.
+    $this->ogAccess = new OgAccess($config_factory->reveal(), $account_proxy->reveal(), $module_handler->reveal());
 
     // Set the Og::cache property values, to skip calculations.
     $values = [];
@@ -112,9 +138,9 @@ class OgAccessTestBase extends UnitTestCase {
     ];
     $identifier = implode(':', $identifier);
 
-    // The cache is supposed to be holding the OG membership, however it is not
-    // used in the tests, so we just set a TRUE value.
-    $values[$identifier] = TRUE;
+    // The cache is supposed to be holding the OG memberships, however it is not
+    // used in the tests, so we just set an empty array.
+    $values[$identifier] = [];
 
     $reflection_property->setValue($values);
 
@@ -123,13 +149,12 @@ class OgAccessTestBase extends UnitTestCase {
     $reflection_property = $r->getProperty('permissionsCache');
     $reflection_property->setAccessible(TRUE);
 
-
     $values = [];
     foreach (['pre_alter', 'post_alter'] as $key) {
       $values[$group_type_id][$this->group->id()][2][$key] = ['permissions' => ['update group']];
     }
 
-    $reflection_property->setValue($values);
+    $reflection_property->setValue($this->ogAccess, $values);
   }
 
   /**

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -73,15 +73,19 @@ class OgAccessTestBase extends UnitTestCase {
     $this->config = $this->addCache($this->prophesize(Config::class));
     $this->config->get('group_manager_full_access')->willReturn(FALSE);
 
-    // Since access depends on the 'group_manager_full_access' setting this
-    // means that access varies by the config object that contains this setting.
-    // It is expected that the cacheability metadata is retrieved from it.
+    // Whether or not the user has access to a certain operation depends in part
+    // on the 'group_manager_full_access' setting which is stored in config.
+    // Since the access is cached, this means that from the point of view from
+    // the caching system this access varies by the 'og.settings' config object
+    // that contains this setting. It is hence expected that the cacheability
+    // metadata is retrieved from the config object so it can be attached to the
+    // access result object.
+    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
+    $config_factory->get('og.settings')->willReturn($this->config);
+
     $this->config->getCacheContexts()->willReturn([]);
     $this->config->getCacheTags()->willReturn([]);
     $this->config->getCacheMaxAge()->willReturn(0);
-
-    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
-    $config_factory->get('og.settings')->willReturn($this->config);
 
     $this->user = $this->prophesize(AccountInterface::class);
     $this->user->isAuthenticated()->willReturn(TRUE);


### PR DESCRIPTION
Currently `OgAccess` consists of a collection of static methods. When we initially started the D8 port it made sense to use static methods so we could iterate rapidly, but currently this is starting to impede progress.

This PR converts `OgAccess` into a proper service that uses the dependency injection container for its dependencies, so it can be properly mocked in unit tests.
