### PR TITLE
Clean up and clarify the OgAccess unit tests

### DIFF
--- a/tests/src/Unit/OgAccessEntityTest.php
+++ b/tests/src/Unit/OgAccessEntityTest.php
@@ -18,7 +18,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
 
   /**
    * @coversDefaultmethod ::userAccessEntity
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testAccessByOperation($operation) {
     $group_entity = $this->groupEntity();
@@ -34,7 +34,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
 
   /**
    * @coversDefaultmethod ::userAccessEntity
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testEntityNew($operation) {
     $group_entity = $this->groupEntity();
@@ -45,7 +45,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
 
   /**
    * @coversDefaultmethod ::userAccessEntity
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);

--- a/tests/src/Unit/OgAccessEntityTest.php
+++ b/tests/src/Unit/OgAccessEntityTest.php
@@ -23,7 +23,8 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
   public function testAccessByOperation($operation) {
     $group_entity = $this->groupEntity();
     $group_entity->isNew()->willReturn(FALSE);
-    $user_access = $this->ogAccess->userAccessEntity($operation, $this->entity->reveal(), $this->user->reveal());
+
+    $user_access = $this->ogAccess->userAccessEntity($operation, $this->groupContentEntity->reveal(), $this->user->reveal());
 
     // We populate the allowed permissions cache in
     // OgAccessEntityTestBase::setup().
@@ -48,7 +49,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
    */
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
-    $user_entity_access = $this->ogAccess->userAccessEntity($operation, $this->entity->reveal(), $this->user->reveal());
+    $user_entity_access = $this->ogAccess->userAccessEntity($operation, $this->groupContentEntity->reveal(), $this->user->reveal());
     $this->assertTrue($user_entity_access->isAllowed());
   }
 

--- a/tests/src/Unit/OgAccessEntityTestBase.php
+++ b/tests/src/Unit/OgAccessEntityTestBase.php
@@ -21,18 +21,20 @@ use Prophecy\Argument;
 
 class OgAccessEntityTestBase extends OgAccessTestBase {
 
-  protected $entity;
+  /**
+   * A test group content entity.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $groupContentEntity;
 
+  /**
+   * {@inheritdoc}
+   */
   public function setup() {
     parent::setUp();
 
-    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
-    $field_definition->getType()->willReturn(OgGroupAudienceHelper::NON_USER_TO_GROUP_REFERENCE_FIELD_TYPE);
-    $field_definition->getFieldStorageDefinition()
-      ->willReturn($this->prophesize(FieldStorageDefinitionInterface::class)->reveal());
-    $field_definition->getSetting("handler_settings")->willReturn([]);
-    $field_definition->getName()->willReturn($this->randomMachineName());
-
+    // Mock a group content entity.
     $entity_type_id = $this->randomMachineName();
     $bundle = $this->randomMachineName();
 
@@ -44,14 +46,23 @@ class OgAccessEntityTestBase extends OgAccessTestBase {
     $entity_type->isSubclassOf(FieldableEntityInterface::class)->willReturn(TRUE);
     $entity_type->id()->willReturn($entity_type_id);
 
-    $this->entity = $this->prophesize(ContentEntityInterface::class);
-    $this->entity->id()->willReturn($entity_id);
-    $this->entity->bundle()->willReturn($bundle);
-    $this->entity->isNew()->willReturn(FALSE);
-    $this->entity->getEntityType()->willReturn($entity_type->reveal());
-    $this->entity->getEntityTypeId()->willReturn($entity_type_id);
+    $this->groupContentEntity = $this->prophesize(ContentEntityInterface::class);
+    $this->groupContentEntity->id()->willReturn($entity_id);
+    $this->groupContentEntity->bundle()->willReturn($bundle);
+    $this->groupContentEntity->isNew()->willReturn(FALSE);
+    $this->groupContentEntity->getEntityType()->willReturn($entity_type->reveal());
+    $this->groupContentEntity->getEntityTypeId()->willReturn($entity_type_id);
 
+    // The group manager is expected to declare that this is not a group.
     $this->groupManager->isGroup($entity_type_id, $bundle)->willReturn(FALSE);
+
+    // Mock retrieval of field definitions.
+    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
+    $field_definition->getType()->willReturn(OgGroupAudienceHelper::NON_USER_TO_GROUP_REFERENCE_FIELD_TYPE);
+    $field_definition->getFieldStorageDefinition()
+      ->willReturn($this->prophesize(FieldStorageDefinitionInterface::class)->reveal());
+    $field_definition->getSetting('handler_settings')->willReturn([]);
+    $field_definition->getName()->willReturn($this->randomMachineName());
 
     $entity_field_manager = $this->prophesize(EntityFieldManagerInterface::class);
     $entity_field_manager->getFieldDefinitions($entity_type_id, $bundle)->willReturn([$field_definition->reveal()]);
@@ -63,7 +74,6 @@ class OgAccessEntityTestBase extends OgAccessTestBase {
     $entity_type_manager = $this->prophesize(EntityTypeManagerInterface::class);
     $entity_type_manager->getDefinition($entity_type_id)->willReturn($entity_type->reveal());
     $entity_type_manager->getStorage($group_type_id)->willReturn($storage->reveal());
-
 
     $container = \Drupal::getContainer();
     $container->set('entity_type.manager', $entity_type_manager->reveal());

--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -23,7 +23,7 @@ class OgAccessHookTest extends OgAccessEntityTestBase {
   /**
    * Tests that an entity which is not a group or group content is ignored.
    *
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testNotContentEntity($operation) {
     $entity = $this->prophesize(EntityInterface::class);
@@ -37,14 +37,14 @@ class OgAccessHookTest extends OgAccessEntityTestBase {
   /**
    * Tests that an administrator with 'administer group' permission has access.
    *
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
     $user_entity_access = og_entity_access($this->groupContentEntity->reveal(), $operation, $this->user->reveal());
 
     // @todo This is strange, 'view' is not part of the operations supplied by
-    //   ::operationProvider(). And why would a group administrator be allowed
+    //   ::permissionsProvider(). And why would a group administrator be allowed
     //   access to all operations, except 'view'? Shouldn't this also return
     //   'allowed'?
     if ($operation == 'view') {

--- a/tests/src/Unit/OgAccessTest.php
+++ b/tests/src/Unit/OgAccessTest.php
@@ -17,7 +17,7 @@ class OgAccessTest extends OgAccessTestBase {
 
   /**
    * @coversDefaultmethod ::userAccess
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testUserAccessNotAGroup($operation) {
     $this->groupManager->isGroup($this->entityTypeId, $this->bundle)->willReturn(FALSE);
@@ -27,7 +27,7 @@ class OgAccessTest extends OgAccessTestBase {
 
   /**
    * @coversDefaultmethod ::userAccess
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testAccessByOperation($operation) {
     $user_access = $this->ogAccess->userAccess($this->group, $operation, $this->user->reveal());
@@ -41,7 +41,7 @@ class OgAccessTest extends OgAccessTestBase {
 
   /**
    * @coversDefaultmethod ::userAccess
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testUserAccessUser1($operation) {
     $this->user->id()->willReturn(1);
@@ -51,7 +51,7 @@ class OgAccessTest extends OgAccessTestBase {
 
   /**
    * @coversDefaultmethod ::userAccess
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testUserAccessAdminPermission($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
@@ -61,7 +61,7 @@ class OgAccessTest extends OgAccessTestBase {
 
   /**
    * @coversDefaultmethod ::userAccess
-   * @dataProvider operationProvider
+   * @dataProvider permissionsProvider
    */
   public function testUserAccessOwner($operation) {
     $this->config->get('group_manager_full_access')->willReturn(TRUE);

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -216,15 +216,12 @@ class OgAccessTestBase extends UnitTestCase {
   }
 
   /**
-   * Provides operations to use in access tests.
+   * Provides permissions to use in access tests.
    *
    * @return array
-   *   An array of test operations.
-   *
-   * @todo These are not really 'operations' but rather 'permissions', rename
-   *   this?
+   *   An array of test permissions.
    */
-  public function operationProvider() {
+  public function permissionsProvider() {
     return [
       // In the unit tests we don't really care about the permission name - it
       // can be an arbitrary string; except for OgAccessTest::testUserAccessAdminPermission


### PR DESCRIPTION
The OgAccess unit tests are sparsely documented which makes them very confusing to work with. Also it has a property which is very vaguely named `$entity`, but it is not clear when looking at the tests whether this is a group, or group content, or any other entity.

Let's add some documentation and do some general spring cleaning.
