### PR TITLE
OgMembership::getUser always returns NULL

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -105,7 +105,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getUser() {
-    return $this->get('uid')->value;
+    return $this->get('uid')->entity;
   }
 
   /**
@@ -255,7 +255,8 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
     $fields['uid'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Member entity ID'))
       ->setDescription(t('The entity ID of the member.'))
-      ->setTargetEntityTypeId('user');
+      ->setSetting('target_type', 'user')
+      ->setDefaultValue(0);
 
     $fields['entity_type'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Group entity type'))

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -12,8 +12,8 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\og\Exception\OgException;
 use Drupal\og\Og;
-use Drupal\og\OgAccess;
 use Drupal\og\OgGroupAudienceHelper;
 use Drupal\og\OgMembershipInterface;
 
@@ -253,10 +253,9 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
       ->setSetting('target_type', 'og_membership_type');
 
     $fields['uid'] = BaseFieldDefinition::create('entity_reference')
-      ->setLabel(t('Member entity ID'))
-      ->setDescription(t('The entity ID of the member.'))
-      ->setSetting('target_type', 'user')
-      ->setDefaultValue(0);
+      ->setLabel(t('Member User ID'))
+      ->setDescription(t('The user ID of the member.'))
+      ->setSetting('target_type', 'user');
 
     $fields['entity_type'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Group entity type'))
@@ -296,13 +295,22 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function PreSave(EntityStorageInterface $storage) {
+  public function preSave(EntityStorageInterface $storage) {
 
     if (!$this->getFieldName()) {
       $this->setFieldName(OgGroupAudienceHelper::DEFAULT_FIELD);
     }
 
-    parent::PreSave($storage);
+    // Check the value directly rather than using the entity, if there is one.
+    // This will watch actual empty values and '0'.
+    if (!$this->get('uid')->target_id) {
+      // Throw a generic logic exception as this will likely get caught in
+      // \Drupal\Core\Entity\Sql\SqlContentEntityStorage::save and turned in an
+      // EntityStorageException anyway.
+      throw new \LogicException('OG membership can not be created for an empty or anonymous user.');
+    }
+
+    parent::preSave($storage);
   }
 
   /**

--- a/tests/src/Kernel/Entity/EntityCreateAccessTest.php
+++ b/tests/src/Kernel/Entity/EntityCreateAccessTest.php
@@ -82,10 +82,15 @@ class EntityCreateAccessTest extends KernelTestBase {
    * Tests that users that can only view cannot access the entity creation form.
    */
   function testViewPermissionDoesNotGrantCreateAccess() {
+    // Create test user.
+    $user = User::create(['name' => $this->randomString()]);
+    $user->save();
+
     // Create a group.
     Node::create([
       'title' => $this->randomString(),
       'type' => 'group',
+      'uid' => $user->id(),
     ])->save();
 
     // Make sure the anonymous user exists. This normally is created in the

--- a/tests/src/Kernel/Entity/GetGroupContentTest.php
+++ b/tests/src/Kernel/Entity/GetGroupContentTest.php
@@ -9,6 +9,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelper;
+use Drupal\user\Entity\User;
 
 /**
  * Tests getting the group content of a group.
@@ -38,6 +39,13 @@ class GetGroupContentTest extends KernelTestBase {
   protected $entityTypeManager;
 
   /**
+   * The group admin user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $groupAdmin;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {
@@ -52,6 +60,10 @@ class GetGroupContentTest extends KernelTestBase {
 
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface entityTypeManager */
     $this->entityTypeManager = $this->container->get('entity_type.manager');
+
+    // Create group admin user.
+    $this->groupAdmin = User::create(['name' => $this->randomString()]);
+    $this->groupAdmin->save();
   }
 
   /**
@@ -71,6 +83,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups['node'] = Node::create([
       'title' => $this->randomString(),
       'type' => $bundle,
+      'uid' => $this->groupAdmin->id(),
     ]);
     $groups['node']->save();
 
@@ -82,6 +95,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups['entity_test'] = EntityTest::create([
       'type' => $bundle,
       'name' => $this->randomString(),
+      'uid' => $this->groupAdmin->id(),
     ]);
     $groups['entity_test']->save();
 
@@ -167,6 +181,7 @@ class GetGroupContentTest extends KernelTestBase {
       $groups[$i] = Node::create([
         'title' => $this->randomString(),
         'type' => $bundle,
+        'uid' => $this->groupAdmin->id(),
       ]);
       $groups[$i]->save();
     }
@@ -220,6 +235,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups['node'] = Node::create([
       'title' => $this->randomString(),
       'type' => $bundle,
+      'uid' => $this->groupAdmin->id()
     ]);
     $groups['node']->save();
 
@@ -231,6 +247,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups['entity_test'] = EntityTest::create([
       'type' => $bundle,
       'name' => $this->randomString(),
+      'uid' => $this->groupAdmin->id(),
     ]);
     $groups['entity_test']->save();
 

--- a/tests/src/Kernel/Entity/GetGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetGroupsTest.php
@@ -9,6 +9,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelper;
+use Drupal\user\Entity\User;
 
 /**
  * Tests retrieving groups associated with a given group content.
@@ -69,6 +70,10 @@ class GetGroupsTest extends KernelTestBase {
 
     $this->groups = [];
 
+    // Create group admin user.
+    $group_admin = User::create(['name' => $this->randomString()]);
+    $group_admin->save();
+
     // Create four groups of two different entity types.
     for ($i = 0; $i < 2; $i++) {
       $bundle = "node_$i";
@@ -81,6 +86,7 @@ class GetGroupsTest extends KernelTestBase {
       $group = Node::create([
         'title' => $this->randomString(),
         'type' => $bundle,
+        'uid' => $group_admin->id(),
       ]);
       $group->save();
       $this->groups['node'][] = $group;
@@ -93,6 +99,7 @@ class GetGroupsTest extends KernelTestBase {
       $group = EntityTest::create([
         'type' => $bundle,
         'name' => $this->randomString(),
+        'uid' => $group_admin->id(),
       ]);
       $group->save();
       $this->groups['entity_test'][] = $group;

--- a/tests/src/Kernel/Entity/GetUserMembershipsTest.php
+++ b/tests/src/Kernel/Entity/GetUserMembershipsTest.php
@@ -56,6 +56,10 @@ class GetUserMembershipsTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installSchema('system', 'sequences');
 
+    // Create group admin user.
+    $group_admin = User::create(['name' => $this->randomString()]);
+    $group_admin->save();
+
     // Create two groups.
     for ($i = 0; $i < 2; $i++) {
       $bundle = "node_$i";
@@ -68,6 +72,7 @@ class GetUserMembershipsTest extends KernelTestBase {
       $group = Node::create([
         'title' => $this->randomString(),
         'type' => $bundle,
+        'uid' => $group_admin->id(),
       ]);
       $group->save();
       $this->groups[] = $group;

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\og\Kernel\Entity\OgMembershipTest.
+ */
+
+namespace Drupal\Tests\og\Kernel\Entity;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\og\Entity\OgMembership;
+use Drupal\og\Og;
+use Drupal\og\OgMembershipInterface;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests the OgMembership entity.
+ *
+ * @group og
+ * @coversDefaultClass \Drupal\og\Entity\OgMembership
+ */
+class OgMembershipTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'entity_test',
+    'field',
+    'og',
+    'system',
+    'user',
+  ];
+
+  /**
+   * Test group.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $group;
+
+  /**
+   * Test users.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig(['og']);
+    $this->installEntitySchema('og_membership');
+    $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('user');
+    $this->installSchema('system', 'sequences');
+
+    // Create a bundle and add as a group
+    $group = EntityTest::create([
+      'type' => Unicode::strtolower($this->randomMachineName()),
+      'name' => $this->randomString(),
+    ]);
+
+    $group->save();
+    $this->group = $group;
+
+    // Add that as a group.
+    Og::groupManager()->addGroup('entity_test', $group->id());
+
+    // Create test user.
+    $user = User::create(['name' => $this->randomString()]);
+    $user->save();
+
+    $this->user = $user;
+  }
+
+  /**
+   * Tests getting abd setting users on OgMemberships.
+   *
+   * @covers ::getUser
+   * @covers ::setUser
+   */
+  public function testGetSetUser() {
+    $membership = OgMembership::create(['type' => OgMembershipInterface::TYPE_DEFAULT]);
+    $membership
+      ->setUser($this->user)
+      ->setEntityId($this->group->id())
+      ->setGroupEntityType($this->group->getEntityTypeId())
+      ->save();
+
+    // Check the user is returned.
+    $this->assertEquals($this->user->id(), $membership->getUser()->id());
+
+    // And after re-loading.
+    $membership = Og::membershipStorage()->loadUnchanged($membership->id());
+
+    $this->assertEquals($this->user->id(), $membership->getUser()->id());
+  }
+
+  /**
+   * Tests exceptions are thrown when trying to save a membership with no, or
+   * anonymous user.
+   *
+   * @covers ::getUser
+   * @dataProvider providerTestGetSetUserException
+   * @expectedException \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testGetSetUserException($user_value) {
+    /** @var OgMembership $membership */
+    $membership = OgMembership::create(['type' => OgMembershipInterface::TYPE_DEFAULT]);
+    $membership
+      ->setUser($user_value)
+      ->setEntityId($this->group->id())
+      ->setGroupEntityType($this->group->getEntityTypeId())
+      ->save();
+  }
+
+  /**
+   * Data provider for testGetSetUserException.
+   */
+  public function providerTestGetSetUserException() {
+    return [
+      [NULL],
+      [0]
+    ];
+  }
+
+}

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -1,21 +1,15 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\Tests\og\Kernel\Entity\OgMembershipTest.
- */
-
 namespace Drupal\Tests\og\Kernel\Entity;
 
 use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembership;
 use Drupal\og\Og;
 use Drupal\og\OgMembershipInterface;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Tests the OgMembership entity.
@@ -44,7 +38,7 @@ class OgMembershipTest extends KernelTestBase {
   protected $group;
 
   /**
-   * Test users.
+   * Test user.
    *
    * @var \Drupal\user\UserInterface
    */
@@ -82,7 +76,7 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
-   * Tests getting abd setting users on OgMemberships.
+   * Tests getting and setting users on OgMemberships.
    *
    * @covers ::getUser
    * @covers ::setUser
@@ -90,17 +84,19 @@ class OgMembershipTest extends KernelTestBase {
   public function testGetSetUser() {
     $membership = OgMembership::create(['type' => OgMembershipInterface::TYPE_DEFAULT]);
     $membership
-      ->setUser($this->user)
+      ->setUser($this->user->id())
       ->setEntityId($this->group->id())
       ->setGroupEntityType($this->group->getEntityTypeId())
       ->save();
 
     // Check the user is returned.
+    $this->assertInstanceOf(UserInterface::class, $membership->getUser());
     $this->assertEquals($this->user->id(), $membership->getUser()->id());
 
     // And after re-loading.
     $membership = Og::membershipStorage()->loadUnchanged($membership->id());
 
+    $this->assertInstanceOf(UserInterface::class, $membership->getUser());
     $this->assertEquals($this->user->id(), $membership->getUser()->id());
   }
 

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -9,6 +9,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelper;
+use Drupal\user\Entity\User;
 
 /**
  * Tests deletion of orphaned group content and memberships.
@@ -69,10 +70,15 @@ class OgDeleteOrphansTest extends KernelTestBase {
     ])->save();
     Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $group_content_bundle);
 
+    // Create group admin user.
+    $group_admin = User::create(['name' => $this->randomString()]);
+    $group_admin->save();
+
     // Create a group.
     $this->group = Node::create([
       'title' => $this->randomString(),
       'type' => $group_bundle,
+      'uid' => $group_admin->id(),
     ]);
     $this->group->save();
 


### PR DESCRIPTION
~~Will add the start of OgMembershipTest too.....~~

There are two main problems:
- The getUser() method return $field_item->value which will not load the user, or ever return anything.
- The base field definition configuration is wrong, so a user will not get loaded from a correctly set target_id.
