### PR TITLE
Remove auto-prefixing on save since this prefixes already-prefixed ro…

### DIFF
--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -186,18 +186,7 @@ class OgRole extends Role implements OgRoleInterface {
       if (empty($this->getGroupBundle())) {
         throw new ConfigValueException('The group bundle can not be empty.');
       }
-
-      // When assigning a role to group we need to add a prefix to the ID in
-      // order to prevent duplicate IDs.
-      $prefix = $this->getGroupType() . '-' . $this->getGroupBundle() . '-';
-
-      if (!empty($this->getGroupId())) {
-        $prefix .= $this->getGroupId() . '-';
-      }
-
-      $this->id = $prefix . $this->id();
     }
-
     parent::save();
   }
 


### PR DESCRIPTION
…le entities during configuration import.

This doesn't yet re-add the prefixing anywhere. Could do that in the form maybe? Or add validation to stop duplicates being created?
