### PR TITLE
Add OgMembership views data handler

### DIFF
--- a/og.views.inc
+++ b/og.views.inc
@@ -3,6 +3,21 @@
 use Drupal\field\FieldStorageConfigInterface;
 
 /**
+ * Implements hook_views_data_alter().
+ */
+function og_views_data_alter(array &$data) {
+  // Add relationship to og_membership from users.
+  $data['users']['og_membership']['relationship'] = [
+    'real field' => 'uid',
+    'base' => 'og_membership',
+    'base field' => 'uid',
+    'label' => t('OG Membership'),
+    'title' => t('OG Membership'),
+    'id' => 'standard',
+  ];
+}
+
+/**
  * Implements hook_field_views_data().
  *
  * This is an almost verbatim copy of core_field_views_data() except for the

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -73,6 +73,9 @@ use Drupal\og\OgMembershipInterface;
  *   },
  *   bundle_keys = {
  *     "bundle" = "type"
+ *   },
+ *   handlers = {
+ *     "views_data" = "Drupal\og\OgMembershipViewsData",
  *   }
  * )
  */

--- a/src/OgMembershipViewsData.php
+++ b/src/OgMembershipViewsData.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\og\OgMembershipViewsData.
+ */
+
+namespace Drupal\og;
+
+use Drupal\views\EntityViewsData;
+
+/**
+ * Provides the views data for the OG Membership entity type.
+ */
+class OgMembershipViewsData extends EntityViewsData {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getViewsData() {
+    $data = parent::getViewsData();
+
+    return $data;
+  }
+
+}


### PR DESCRIPTION
Currently the OG Membership has no views integration, you just get the 'rendered entity' item added by views, not even the individual og membership fields yet. The core EntityViewsData will give us a nice start and at least expose the fields. We can then start porting the actual handlers one by one. This keeps it manageable.

I also added one relationship from user to og_membership, as that is simple, but very useful and the existing relationship handler will work fine for that.

I don't really think this needs tests yet, as core already has a lot of tests for the EntityViewsData class and the generic views table definitions it provides. The tests will likely come with the individual OG specific handlers.
