### PR TITLE
Workaround for core bug #2752315

### DIFF
--- a/og_ui/tests/src/Functional/BundleFormAlterTest.php
+++ b/og_ui/tests/src/Functional/BundleFormAlterTest.php
@@ -164,4 +164,15 @@ class BundleFormAlterTest extends BrowserTestBase {
     $this->assertEquals($expected, $setting, $message);
   }
 
+  /**
+   * Temporary workaround for a core bug that has the visibility wrong for this.
+   *
+   * Remove this once issue #2752315 is fixed.
+   *
+   * @see https://www.drupal.org/node/2752315
+   */
+  public function assertNoEscaped($raw) {
+    $this->assertSession()->assertNoEscaped($raw);
+  }
+
 }


### PR DESCRIPTION
Core issue [#2735199: Convert web tests to browser tests for help module](https://www.drupal.org/node/2735199) which was merged this weekend introduced a new legacy assertion method `assertNoEscaped()` in browser tests, but this has the wrong visibility. This currently causes our tests on 8.2.x to break with the following error message:

> PHP Fatal error:  Access level to Drupal\simpletest\AssertContentTrait::assertNoEscaped() must be public (as in class Drupal\Tests\BrowserTestBase) in /home/travis/build/amitaibu/og/og_ui/tests/src/Functional/BundleFormAlterTest.php on line 24

A fix is proposed in [#2752315: Fix visibility of AssertLegacyTrait::assertNoEscaped()](https://www.drupal.org/node/2752315) but this has not been reviewed yet.

This PR temporarily works around the problem so we can continue working on OG.

This is very similar to the failure we had in #223.
