### PR TITLE
Check permissions for non-member

### DIFF
--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -237,6 +237,9 @@ class OgRole extends Role implements OgRoleInterface {
       $this->setId($prefix . $this->getName());
     }
 
+    // Reset access cache, as the role might have changed.
+    $this->ogAccess()->reset();
+
     parent::save();
   }
 
@@ -275,6 +278,9 @@ class OgRole extends Role implements OgRoleInterface {
     if (in_array($this->id(), [self::ANONYMOUS, self::AUTHENTICATED]) && $this->groupManager()->isGroup($this->getGroupType(), $this->getGroupBundle())) {
       throw new OgRoleException('The default roles "non-member" and "member" cannot be deleted.');
     }
+
+    // Reset access cache, as the role is no longer present.
+    $this->ogAccess()->reset();
     parent::delete();
   }
 
@@ -312,6 +318,16 @@ class OgRole extends Role implements OgRoleInterface {
     // See for example Entity::uuidGenerator() in the base Entity class, it
     // also uses this pattern.
     return \Drupal::service('og.group.manager');
+  }
+
+  /**
+   * Gets the OG access service.
+   *
+   * @return \Drupal\og\OgAccessInterface
+   *   The OG access service.
+   */
+  protected function ogAccess() {
+    return \Drupal::service('og.access');
   }
 
 }

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -152,6 +152,12 @@ class OgAccess implements OgAccessInterface {
           $permissions = array_merge($permissions, $role->getPermissions());
         }
       }
+      else {
+        // User is a non-member.
+        /** @var \Drupal\og\Entity\OgRole $role */
+        $role = Og::getRole($group_type_id, $bundle, OgRoleInterface::ANONYMOUS);
+        $permissions = $role->getPermissions();
+      }
 
       $permissions = array_unique($permissions);
 

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -9,7 +9,6 @@ use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgAccess;
-use Drupal\og\OgAccessInterface;
 use Drupal\og\OgRoleInterface;
 use Drupal\user\Entity\User;
 

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -9,6 +9,7 @@ use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgAccess;
+use Drupal\og\OgAccessInterface;
 use Drupal\og\OgRoleInterface;
 use Drupal\user\Entity\User;
 
@@ -272,6 +273,7 @@ class OgEntityAccessTest extends KernelTestBase {
    * Test access to an arbitrary permission.
    */
   public function testAccess() {
+    /** @var OgAccessInterface $og_access */
     $og_access = $this->container->get('og.access');
 
     // A member user.
@@ -295,6 +297,7 @@ class OgEntityAccessTest extends KernelTestBase {
       ->grantPermission('some_perm')
       ->save();
 
+    $og_access->reset();
     $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user3)->isAllowed());
 
     // A member with permission to update the group. The operation edit is

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -297,7 +297,6 @@ class OgEntityAccessTest extends KernelTestBase {
       ->grantPermission('some_perm')
       ->save();
 
-    $og_access->reset();
     $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user3)->isAllowed());
 
     // A member with permission to update the group. The operation edit is

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -9,6 +9,7 @@ use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgAccess;
+use Drupal\og\OgRoleInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -244,7 +245,6 @@ class OgEntityAccessTest extends KernelTestBase {
       ->addRole($this->ogRoleWithPermission2)
       ->save();
 
-    /** @var OgMembership $membership */
     $membership = OgMembership::create();
     $membership
       ->setUser($this->user2)
@@ -260,7 +260,6 @@ class OgEntityAccessTest extends KernelTestBase {
       ->addRole($this->ogRoleWithUpdatePermission)
       ->save();
 
-    /** @var OgMembership $membership */
     $membership = OgMembership::create();
     $membership
       ->setUser($this->adminUser)
@@ -288,6 +287,15 @@ class OgEntityAccessTest extends KernelTestBase {
 
     // A non-member user.
     $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user3)->isForbidden());
+
+    // Allow the permission to a non-member user.
+    /** @var OgRole $role */
+    $role = Og::getRole('entity_test', $this->groupBundle, OgRoleInterface::ANONYMOUS);
+    $role
+      ->grantPermission('some_perm')
+      ->save();
+
+    $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->user3)->isAllowed());
 
     // A member with permission to update the group. The operation edit is
     // passed to the userAccess method.


### PR DESCRIPTION
`\Drupal\og\OgAccess::userAccess` should take non-members into account.

When we iterate over the user's roles we only take care of the situation they are members. We should explicitly take care also of the non-member case.
