### PR TITLE
add a context provider

### DIFF
--- a/og.services.yml
+++ b/og.services.yml
@@ -22,3 +22,8 @@ services:
   plugin.manager.og.fields:
     class: Drupal\og\OgFieldsPluginManager
     parent: default_plugin_manager
+  og.node_route_context:
+    class: Drupal\og\ContextProvider\OgRouteContext
+    arguments: ['@current_route_match', '@og.group.manager']
+    tags:
+      - { name: 'context_provider' }

--- a/src/ContextProvider/OgRouteContext.php
+++ b/src/ContextProvider/OgRouteContext.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\og\ContextProvider;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\og\GroupManager;
+use Drupal\og\OgGroupAudienceHelper;
+
+class OgRouteContext implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * @var \Drupal\og\GroupManager
+   */
+  protected $groupManager;
+
+  /**
+   * Constructs a new NodeRouteContext.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match object.
+   */
+  public function __construct(RouteMatchInterface $route_match, GroupManager $group_manager) {
+    $this->routeMatch = $route_match;
+    $this->groupManager = $group_manager;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $result = [];
+    $context_definition = new ContextDefinition('entity:node', NULL, FALSE);
+    $value = NULL;
+    if (($route_object = $this->routeMatch->getRouteObject()) && ($route_contexts = $route_object->getOption('parameters')) && isset($route_contexts['node'])) {
+      if (($node = $this->routeMatch->getParameter('node')) && $node instanceof NodeInterface) {
+        if ($this->groupManager->isGroup('node', $node->bundle())) {
+          $value = $node;
+        }
+        foreach (array_keys(OgGroupAudienceHelper::getAllGroupAudienceFields('node', $node->bundle(), 'node')) as $field_name) {
+          if ($node->hasField($field_name) && !$node->$field_name->isEmpty()) {
+            $value = $node->$field_name->entity;
+            break;
+          }
+        }
+      }
+    }
+    $cacheability = new CacheableMetadata();
+    $cacheability->setCacheContexts(['route']);
+
+    $context = new Context($context_definition, $value);
+    $context->addCacheableDependency($cacheability);
+    $result['node'] = $context;
+
+    return $result;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getAvailableContexts() {
+    $context = new Context(new ContextDefinition('entity:node', $this->t('(Containing) group from URL')));
+    return ['node' => $context];
+  }
+
+}


### PR DESCRIPTION
Our site is pretty much split into subsites by group. Displaying the relevant blocks on a group node or a node belonging to a group is possible with this context provider. If it's not generic enough just won't fix this and I will dump it into a separate sandbox module. Here's how placing a block with ` *     "node" = @ContextDefinition("entity:node", label = @Translation("Node"), required = FALSE),` looks:

![selection_315](https://cloud.githubusercontent.com/assets/193045/17280540/c13eb2e0-5746-11e6-8da6-ddc55da4042d.png)
