### PR TITLE
Inject EntityTypeManager in the MembershipManager

### DIFF
--- a/og.services.yml
+++ b/og.services.yml
@@ -7,8 +7,6 @@ services:
   og.access:
     class: Drupal\og\OgAccess
     arguments: ['@config.factory', '@current_user', '@module_handler', '@og.group.manager', '@og.permission_manager', '@og.membership_manager']
-  og.membership_manager:
-    class: Drupal\og\MembershipManager
   og.event_subscriber:
     class: Drupal\og\EventSubscriber\OgEventSubscriber
     arguments: ['@og.permission_manager', '@entity_type.manager', '@entity_type.bundle.info']
@@ -17,6 +15,9 @@ services:
   og.group.manager:
     class: Drupal\og\GroupManager
     arguments: ['@config.factory', '@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@state', '@og.permission_manager']
+  og.membership_manager:
+    class: Drupal\og\MembershipManager
+    arguments: ['@entity_type.manager']
   og.permissions:
     class: Drupal\og\OgPermissionHandler
     arguments: ['@module_handler', '@string_translation', '@controller_resolver']

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -5,7 +5,6 @@ namespace Drupal\og;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\FieldStorageConfigInterface;

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -4,6 +4,8 @@ namespace Drupal\og;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\FieldStorageConfigInterface;
@@ -20,6 +22,23 @@ class MembershipManager implements MembershipManagerInterface {
    * @var array
    */
   protected $cache;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a MembershipManager object.
+   *
+   * @param \Drupal\core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
 
   /**
    * {@inheritdoc}
@@ -43,7 +62,7 @@ class MembershipManager implements MembershipManagerInterface {
     $groups = [];
 
     foreach ($this->getUserGroupIds($user, $states) as $entity_type => $entity_ids) {
-      $groups[$entity_type] = \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple($entity_ids);
+      $groups[$entity_type] = $this->entityTypeManager->getStorage($entity_type)->loadMultiple($entity_ids);
     }
 
     return $groups;
@@ -69,7 +88,9 @@ class MembershipManager implements MembershipManagerInterface {
       return $this->cache[$identifier];
     }
 
-    $query = \Drupal::entityQuery('og_membership')
+    $query = $this->entityTypeManager
+      ->getStorage('og_membership')
+      ->getQuery()
       ->condition('uid', $user->id());
 
     if ($states) {
@@ -79,7 +100,7 @@ class MembershipManager implements MembershipManagerInterface {
     $results = $query->execute();
 
     /** @var \Drupal\og\Entity\OgMembership[] $memberships */
-    $this->cache[$identifier] = \Drupal::entityTypeManager()
+    $this->cache[$identifier] = $this->entityTypeManager
       ->getStorage('og_membership')
       ->loadMultiple($results);
 
@@ -159,8 +180,10 @@ class MembershipManager implements MembershipManagerInterface {
       // Query the database to get the actual list of groups. The target IDs may
       // contain groups that no longer exist. Entity reference doesn't clean up
       // orphaned target IDs.
-      $entity_type = \Drupal::entityTypeManager()->getDefinition($target_type);
-      $query = \Drupal::entityQuery($target_type)
+      $entity_type = $this->entityTypeManager->getDefinition($target_type);
+      $query = $this->entityTypeManager
+        ->getStorage($target_type)
+        ->getQuery()
         ->condition($entity_type->getKey('id'), $target_ids, 'IN');
 
       // Optionally filter by group bundle.
@@ -183,7 +206,7 @@ class MembershipManager implements MembershipManagerInterface {
     $groups = [];
 
     foreach ($this->getGroupIds($entity, $group_type_id, $group_bundle) as $entity_type => $entity_ids) {
-      $groups[$entity_type] = \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple($entity_ids);
+      $groups[$entity_type] = $this->entityTypeManager->getStorage($entity_type)->loadMultiple($entity_ids);
     }
 
     return $groups;
@@ -205,7 +228,9 @@ class MembershipManager implements MembershipManagerInterface {
     $group_content = [];
 
     // Retrieve the fields which reference our entity type and bundle.
-    $query = \Drupal::entityQuery('field_storage_config')
+    $query = $this->entityTypeManager
+      ->getStorage('field_storage_config')
+      ->getQuery()
       ->condition('type', OgGroupAudienceHelper::GROUP_REFERENCE);
 
     // Optionally filter group content entity types.
@@ -231,7 +256,9 @@ class MembershipManager implements MembershipManagerInterface {
       }
 
       // Query all group content that references the group through this field.
-      $results = \Drupal::entityQuery($group_content_entity_type)
+      $results = $this->entityTypeManager
+        ->getStorage($group_content_entity_type)
+        ->getQuery()
         ->condition($field->getName() . '.target_id', $entity->id())
         ->execute();
 

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\MembershipManager;
 use Drupal\og\OgMembershipInterface;
@@ -26,6 +27,13 @@ class CreateMembershipTest extends UnitTestCase {
    * @var \Drupal\Core\Entity\EntityManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $entityManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $entityTypeManager;
 
   /**
    * The entity storage prophecy used in the test.
@@ -80,6 +88,7 @@ class CreateMembershipTest extends UnitTestCase {
 
     $this->entityStorage = $this->prophesize(EntityStorageInterface::class);
     $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+    $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
 
     $this->entityManager->getStorage('og_membership')
       ->willReturn($this->entityStorage->reveal());
@@ -119,7 +128,7 @@ class CreateMembershipTest extends UnitTestCase {
    * @covers ::createMembership
    */
   public function testNewGroup() {
-    $membership_manager = new MembershipManager();
+    $membership_manager = new MembershipManager($this->entityTypeManager->reveal());
     $membership = $membership_manager->createMembership($this->group->reveal(), $this->user->reveal());
     $this->assertInstanceOf(OgMembershipInterface::class, $membership);
   }


### PR DESCRIPTION
Now that we have the `MembershipManager` service, let's inject `EntityTypeManager` into it so we don't have to fall back to the static methods in `\Drupal` and are fully decoupled.
